### PR TITLE
Only run formatting checks on stable Rust.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
 install:
   - rustup component add rustfmt-preview
 script:
-  - rustfmt --error-on-unformatted --write-mode diff src/lib.rs
+  - if [[ ${TRAVIS_RUST_VERSION} == "stable" ]]; then rustfmt --error-on-unformatted --write-mode diff src/lib.rs; fi
   - cargo test --verbose
 matrix:
   allow_failures:


### PR DESCRIPTION
Other rust versions can potentially have other formatting rules.

Related to #8.