### PR TITLE
JVM init arguments type.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
+dist: trusty
 language: rust
 rust:
   - stable
   - beta
   - nightly
+env:
+  global:
+    - LD_LIBRARY_PATH="$JAVA_HOME/jre/lib/amd64/server"
+  matrix:
+    - JDK=oraclejdk8
+    - JDK=openjdk8
+before_script:
+  - jdk_switcher use $JDK
 install:
   - rustup component add rustfmt-preview
 script:
   - if [[ ${TRAVIS_RUST_VERSION} == "stable" ]]; then rustfmt --error-on-unformatted --write-mode diff src/lib.rs; fi
-  - cargo test --verbose
+  - cargo test --verbose --features libjvm
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,13 +9,62 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rust-jni"
 version = "0.1.0"
 dependencies = [
  "cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "same-file"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+"checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
+"checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
+"checksum walkdir 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "63636bd0eb3d00ccb8b9036381b526efac53caf112b7783b730ab3f8e44da369"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,12 @@ authors = ["Monnoroch <monnoroch@gmail.com>"]
 [dependencies]
 cesu8 = "1.1.0"
 jni-sys = "0.3.0"
+
+[dev-dependencies]
+lazy_static = "1"
+
+[build-dependencies]
+walkdir = "2"
+
+[features]
+libjvm = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,36 @@
+extern crate walkdir;
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    if cfg!(feature = "libjvm") {
+        let libjvm_path = env::var("JAVA_HOME").ok().and_then(find_libjvm);
+        match libjvm_path {
+            Some(path) => println!("cargo:rustc-link-search=native={}", path.display()),
+            None => panic!("Failed to find libjvm.so. Try setting JAVA_HOME"),
+        }
+        println!("cargo:rustc-link-lib=dylib=jvm");
+    }
+}
+
+fn find_libjvm<S: AsRef<Path>>(path: S) -> Option<PathBuf> {
+    walkdir::WalkDir::new(path)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_str().unwrap_or("") == java_lib_name())
+        .filter_map(|entry| entry.path().parent().map(Into::into))
+        .next()
+}
+
+// TODO(#15): support Android.
+fn java_lib_name() -> &'static str {
+    if cfg!(target_os = "linux") {
+        "libjvm.so"
+    } else if cfg!(target_os = "windows") {
+        "jvm.dll"
+    } else {
+        "libjvm.dylib"
+    }
+}

--- a/src/init_arguments.rs
+++ b/src/init_arguments.rs
@@ -1,0 +1,669 @@
+use jni_sys;
+use raw::*;
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::os::raw::c_void;
+use std::ptr;
+use std::slice;
+use version::{self, JniVersion};
+
+/// Verbose options for starting a Java VM.
+///
+/// [JNI documentation](https://docs.oracle.com/javase/9/docs/specs/jni/invocation.html#jni_createjavavm)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JvmVerboseOption {
+    /// Verbose class option.
+    ///
+    /// Passed to the JVM as `-verbose:class`.
+    Class,
+    /// Verbose GC option.
+    ///
+    /// Passed to the JVM as `-verbose:gc`.
+    Gc,
+    /// Verbose JNI option.
+    ///
+    /// Passed to the JVM as `-verbose:jni`.
+    Jni,
+}
+
+impl JvmVerboseOption {
+    fn to_string(&self) -> &'static str {
+        match self {
+            JvmVerboseOption::Class => "class",
+            JvmVerboseOption::Gc => "gc",
+            JvmVerboseOption::Jni => "jni",
+        }
+    }
+}
+
+#[cfg(test)]
+mod jvm_verbose_option_test {
+    use super::*;
+
+    #[test]
+    fn to_string() {
+        assert_eq!(JvmVerboseOption::Class.to_string(), "class");
+        assert_eq!(JvmVerboseOption::Gc.to_string(), "gc");
+        assert_eq!(JvmVerboseOption::Jni.to_string(), "jni");
+    }
+}
+
+/// Options for starting a Java VM.
+///
+/// [JNI documentation](https://docs.oracle.com/javase/9/docs/specs/jni/invocation.html#jni_createjavavm)
+// TODO(#13): support vfprintf, exit, abort options.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JvmOption {
+    /// Verbose option string. Is a vector of verbose options.
+    ///
+    /// Passed to the JVM as `-verbose:${verbose_option}`.
+    Verbose(JvmVerboseOption),
+    /// System property option string. Must have a key and a value.
+    ///
+    /// Is formatted as `-D{key}=${value}`.
+    SystemProperty(String, String),
+    /// Enable checking JNI calls.
+    ///
+    /// Passed to the JVM as `-check:jni`.
+    CheckedJni,
+    /// Unknown option.
+    /// Needed for forward compability and to set custom options.
+    Unknown(String),
+}
+
+impl JvmOption {
+    unsafe fn from_raw(option: &jni_sys::JavaVMOption) -> Self {
+        // TODO(#14): support platform encodings other than UTF-8.
+        let option_string = CStr::from_ptr((*option).optionString).to_str().unwrap();
+        let system_property_prefix = "-D";
+        match option_string {
+            "-verbose:gc" => JvmOption::Verbose(JvmVerboseOption::Gc),
+            "-verbose:jni" => JvmOption::Verbose(JvmVerboseOption::Jni),
+            "-verbose:class" => JvmOption::Verbose(JvmVerboseOption::Class),
+            "-Xcheck:jni" => JvmOption::CheckedJni,
+            option if option.starts_with(system_property_prefix) => {
+                let parts: Vec<&str> = option
+                    .split_at(system_property_prefix.len())
+                    .1
+                    .splitn(2, "=")
+                    .collect();
+                if parts.len() != 2 {
+                    JvmOption::Unknown(option.to_owned())
+                } else {
+                    JvmOption::SystemProperty(parts[0].to_owned(), parts[1].to_owned())
+                }
+            }
+            option => JvmOption::Unknown(option.to_owned()),
+        }
+    }
+
+    fn to_string(&self) -> String {
+        match self {
+            JvmOption::CheckedJni => "-Xcheck:jni".to_owned(),
+            JvmOption::Verbose(option) => format!("-verbose:{}", option.to_string()),
+            JvmOption::SystemProperty(key, value) => format!("-D{}={}", key, value),
+            JvmOption::Unknown(value) => value.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod jvm_option_test {
+    use super::*;
+
+    #[test]
+    fn from_raw_checked_jni() {
+        let option_string = CStr::from_bytes_with_nul(b"-Xcheck:jni\0").unwrap();
+        let option = &jni_sys::JavaVMOption {
+            optionString: option_string.as_ptr() as *mut i8,
+            extraInfo: ptr::null_mut(),
+        };
+        assert_eq!(
+            unsafe { JvmOption::from_raw(option) },
+            JvmOption::CheckedJni
+        );
+    }
+
+    #[test]
+    fn from_raw_verbose() {
+        let option_string = CStr::from_bytes_with_nul(b"-verbose:jni\0").unwrap();
+        let option = &jni_sys::JavaVMOption {
+            optionString: option_string.as_ptr() as *mut i8,
+            extraInfo: ptr::null_mut(),
+        };
+        assert_eq!(
+            unsafe { JvmOption::from_raw(option) },
+            JvmOption::Verbose(JvmVerboseOption::Jni)
+        );
+
+        let option_string = CStr::from_bytes_with_nul(b"-verbose:gc\0").unwrap();
+        let option = &jni_sys::JavaVMOption {
+            optionString: option_string.as_ptr() as *mut i8,
+            extraInfo: ptr::null_mut(),
+        };
+        assert_eq!(
+            unsafe { JvmOption::from_raw(option) },
+            JvmOption::Verbose(JvmVerboseOption::Gc)
+        );
+
+        let option_string = CStr::from_bytes_with_nul(b"-verbose:class\0").unwrap();
+        let option = &jni_sys::JavaVMOption {
+            optionString: option_string.as_ptr() as *mut i8,
+            extraInfo: ptr::null_mut(),
+        };
+        assert_eq!(
+            unsafe { JvmOption::from_raw(option) },
+            JvmOption::Verbose(JvmVerboseOption::Class)
+        );
+    }
+
+    #[test]
+    fn from_raw_system_property() {
+        let option_string = CStr::from_bytes_with_nul(b"-Dkey=value\0").unwrap();
+        let option = &jni_sys::JavaVMOption {
+            optionString: option_string.as_ptr() as *mut i8,
+            extraInfo: ptr::null_mut(),
+        };
+        assert_eq!(
+            unsafe { JvmOption::from_raw(option) },
+            JvmOption::SystemProperty("key".to_owned(), "value".to_owned())
+        );
+    }
+
+    #[test]
+    fn from_raw_unknown() {
+        let option_string = CStr::from_bytes_with_nul(b"tyhb\0").unwrap();
+        let option = &jni_sys::JavaVMOption {
+            optionString: option_string.as_ptr() as *mut i8,
+            extraInfo: ptr::null_mut(),
+        };
+        assert_eq!(
+            unsafe { JvmOption::from_raw(option) },
+            JvmOption::Unknown("tyhb".to_owned())
+        );
+
+        let option_string = CStr::from_bytes_with_nul(b"-Dkey~value\0").unwrap();
+        let option = &jni_sys::JavaVMOption {
+            optionString: option_string.as_ptr() as *mut i8,
+            extraInfo: ptr::null_mut(),
+        };
+        assert_eq!(
+            unsafe { JvmOption::from_raw(option) },
+            JvmOption::Unknown("-Dkey~value".to_owned())
+        );
+    }
+
+    #[test]
+    fn to_string() {
+        assert_eq!(JvmOption::CheckedJni.to_string(), "-Xcheck:jni");
+        assert_eq!(
+            JvmOption::Verbose(JvmVerboseOption::Gc).to_string(),
+            "-verbose:gc"
+        );
+        assert_eq!(
+            JvmOption::Verbose(JvmVerboseOption::Jni).to_string(),
+            "-verbose:jni"
+        );
+        assert_eq!(
+            JvmOption::Verbose(JvmVerboseOption::Class).to_string(),
+            "-verbose:class"
+        );
+        assert_eq!(
+            JvmOption::SystemProperty("key".to_owned(), "value".to_owned()).to_string(),
+            "-Dkey=value"
+        );
+        assert_eq!(JvmOption::Unknown("qwer".to_owned()).to_string(), "qwer");
+    }
+}
+
+/// Arguments for creating a Java VM.
+///
+/// [JNI documentation](https://docs.oracle.com/javase/9/docs/specs/jni/invocation.html#jni_createjavavm)
+///
+/// # Example
+/// ```
+/// use rust_jni::{InitArguments, JniVersion, JvmOption, JvmVerboseOption};
+///
+/// let options = InitArguments::get_default(JniVersion::V8).unwrap()
+///     .with_option(JvmOption::Unknown("-Xgc:parallel".to_owned()))
+///     .with_option(JvmOption::Verbose(JvmVerboseOption::Gc));
+///
+/// assert_eq!(options.version(), JniVersion::V8);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitArguments {
+    version: JniVersion,
+    options: Vec<JvmOption>,
+    ignore_unrecognized: bool,
+}
+
+impl InitArguments {
+    /// Get default Java VM init arguments for a JNI version.
+    /// If the requested JNI version is not supported, returns None.
+    ///
+    /// [JNI documentation](https://docs.oracle.com/javase/9/docs/specs/jni/invocation.html#jni_getdefaultjavavminitargs)
+    pub fn get_default(version: JniVersion) -> Option<Self> {
+        let arguments = Self::get_default_or_closest_supported(version);
+        if arguments.version == version {
+            Some(arguments)
+        } else {
+            None
+        }
+    }
+
+    /// Get default Java VM init arguments for a JNI version.
+    /// If the requested JNI version is not supported, returns default arguments for the closest supported JNI version.
+    /// The new version can be obtained with the `InitArguments::version()` method.
+    ///
+    /// [JNI documentation](https://docs.oracle.com/javase/9/docs/specs/jni/invocation.html#jni_getdefaultjavavminitargs)
+    pub fn get_default_or_closest_supported(version: JniVersion) -> Self {
+        let mut raw_arguments = jni_sys::JavaVMInitArgs {
+            version: version::to_raw(version),
+            nOptions: 0,
+            options: ptr::null_mut(),
+            ignoreUnrecognized: jni_sys::JNI_FALSE,
+        };
+        // Safe because we pass a pointer to a correct data structure.
+        unsafe {
+            // It is fine if the requested version is not supported, we'll just use a supported one.
+            JNI_GetDefaultJavaVMInitArgs(
+                &mut raw_arguments as *mut jni_sys::JavaVMInitArgs as *mut c_void,
+            );
+        }
+        // Safe because raw arguments were correctly initialized by the
+        // `JNI_GetDefaultJavaVMInitArgs`.
+        unsafe { Self::from_raw(&raw_arguments).with_option(JvmOption::CheckedJni) }
+    }
+
+    unsafe fn from_raw(raw_arguments: &jni_sys::JavaVMInitArgs) -> InitArguments {
+        let options = slice::from_raw_parts(raw_arguments.options, raw_arguments.nOptions as usize)
+            .iter()
+            .map(|value| JvmOption::from_raw(value))
+            .collect();
+        InitArguments {
+            version: version::from_raw(raw_arguments.version),
+            ignore_unrecognized: to_bool(raw_arguments.ignoreUnrecognized),
+            options,
+        }
+    }
+
+    /// Get default init arguments for the latest supported JNI version.
+    ///
+    /// [JNI documentation](https://docs.oracle.com/javase/9/docs/specs/jni/invocation.html#jni_getdefaultjavavminitargs)
+    pub fn get_latest_default() -> Self {
+        Self::get_default_or_closest_supported(JniVersion::V8)
+    }
+
+    /// Add init options to the Java VM init arguments.
+    ///
+    /// [JNI documentation](https://docs.oracle.com/javase/10/docs/specs/jni/invocation.html#jni_createjavavm)
+    pub fn with_options(mut self, options: &[JvmOption]) -> Self {
+        self.options.extend_from_slice(options);
+        self
+    }
+
+    /// Add an init option to the Java VM init arguments.
+    pub fn with_option(self, option: JvmOption) -> Self {
+        self.with_options(&[option])
+    }
+
+    /// Disable checking JNI calls for correctness.
+    pub fn unchecked(self) -> Self {
+        InitArguments {
+            version: self.version,
+            ignore_unrecognized: self.ignore_unrecognized,
+            options: self.options
+                .iter()
+                .filter(|&option| *option != JvmOption::CheckedJni)
+                .cloned()
+                .collect(),
+        }
+    }
+
+    /// Enable checking JNI calls for correctness.
+    ///
+    /// This is a default. Only needed to be called if checking JNI calls was explicitly disabled.
+    pub fn checked(self) -> Self {
+        self.with_option(JvmOption::CheckedJni)
+    }
+
+    /// Request for JVM to ignore unrecognized options on startup.
+    pub fn ignoring_unrecognized_options(mut self) -> Self {
+        self.ignore_unrecognized = true;
+        self
+    }
+
+    /// Request for JVM to fail in presence of unrecognized options on startup.
+    pub fn failing_on_unrecognized_options(mut self) -> Self {
+        self.ignore_unrecognized = false;
+        self
+    }
+
+    /// Return the JNI version this arguments will request when creating a Java VM.
+    pub fn version(&self) -> JniVersion {
+        self.version
+    }
+}
+
+/// A wrapper around `jni_sys::JavaVMInitArgs` with a lifetime to ensure
+/// there's no access to freed memory.
+pub struct RawInitArguments<'a> {
+    raw_arguments: jni_sys::JavaVMInitArgs,
+    _buffer: PhantomData<&'a Vec<CString>>,
+}
+
+pub fn to_raw<'a, 'b, 'c: 'a + 'b>(
+    arguments: &InitArguments,
+    strings_buffer: &'a mut Vec<CString>,
+    options_buffer: &'b mut Vec<jni_sys::JavaVMOption>,
+) -> RawInitArguments<'c> {
+    *strings_buffer = arguments
+        .options
+        .iter()
+        .map(|_| "")
+        .map(CString::new)
+        .map(Result::unwrap)
+        .collect();
+    *options_buffer = arguments
+        .options
+        .iter()
+        .zip(strings_buffer.iter_mut())
+        .map(|(option, ref mut buffer)| {
+            // TODO(#14): support platform encodings other than UTF-8.
+            let buffer: &mut CString = buffer;
+            *buffer = CString::new(option.to_string()).unwrap();
+            jni_sys::JavaVMOption {
+                optionString: buffer.as_ptr() as *mut i8,
+                extraInfo: ptr::null_mut(),
+            }
+        })
+        .collect();
+    RawInitArguments {
+        raw_arguments: jni_sys::JavaVMInitArgs {
+            version: version::to_raw(arguments.version),
+            nOptions: options_buffer.len() as i32,
+            options: options_buffer.as_mut_ptr(),
+            ignoreUnrecognized: from_bool(arguments.ignore_unrecognized),
+        },
+        _buffer: PhantomData::<&'c Vec<CString>>,
+    }
+}
+
+#[cfg(test)]
+pub mod init_arguments_tests {
+    use super::*;
+
+    fn default_options() -> Vec<JvmOption> {
+        vec![
+            JvmOption::SystemProperty("key".to_owned(), "value".to_owned()),
+            JvmOption::Unknown("qwer".to_owned()),
+        ]
+    }
+
+    fn resulting_options() -> Vec<JvmOption> {
+        vec![
+            JvmOption::SystemProperty("key".to_owned(), "value".to_owned()),
+            JvmOption::Unknown("qwer".to_owned()),
+            JvmOption::CheckedJni,
+        ]
+    }
+
+    pub fn default_args() -> InitArguments {
+        InitArguments {
+            version: JniVersion::V4,
+            options: default_options(),
+            ignore_unrecognized: false,
+        }
+    }
+
+    fn check_arguments(version: JniVersion) {
+        let actual_arguments = get_default_java_vm_init_args_call_input();
+        assert_eq!(actual_arguments.version, version::to_raw(version));
+        assert_eq!(actual_arguments.nOptions, 0);
+        assert_eq!(actual_arguments.options, ptr::null_mut());
+        assert_eq!(actual_arguments.ignoreUnrecognized, jni_sys::JNI_FALSE);
+    }
+
+    #[test]
+    fn to_raw_test() {
+        let arguments = InitArguments {
+            version: JniVersion::V4,
+            options: default_options(),
+            ignore_unrecognized: false,
+        };
+        let mut strings_buffer = vec![];
+        let mut options_buffer = vec![];
+        let raw_arguments = to_raw(&arguments, &mut strings_buffer, &mut options_buffer);
+        assert_eq!(
+            raw_arguments.raw_arguments.version,
+            version::to_raw(JniVersion::V4)
+        );
+        assert_eq!(raw_arguments.raw_arguments.nOptions, 2);
+        assert_eq!(
+            raw_arguments.raw_arguments.ignoreUnrecognized,
+            jni_sys::JNI_FALSE
+        );
+        let raw_options = unsafe {
+            slice::from_raw_parts(
+                raw_arguments.raw_arguments.options,
+                raw_arguments.raw_arguments.nOptions as usize,
+            )
+        };
+        for (raw_option, option) in raw_options.iter().zip(default_options().into_iter()) {
+            assert_eq!(option, unsafe { JvmOption::from_raw(raw_option) });
+        }
+    }
+
+    #[test]
+    fn get_default_supported() {
+        let mut strings_buffer = vec![];
+        let mut options_buffer = vec![];
+        let mut raw_arguments = to_raw(&default_args(), &mut strings_buffer, &mut options_buffer);
+        let _locked = setup_get_default_java_vm_init_args_call(GetDefaultJavaVMInitArgsCall::new(
+            &mut raw_arguments.raw_arguments as *mut jni_sys::JavaVMInitArgs as *mut c_void,
+        ));
+        assert_eq!(
+            InitArguments::get_default(JniVersion::V4),
+            Some(InitArguments {
+                version: JniVersion::V4,
+                options: resulting_options(),
+                ignore_unrecognized: false
+            })
+        );
+        check_arguments(JniVersion::V4);
+    }
+
+    #[test]
+    fn get_default_unsupported() {
+        let mut strings_buffer = vec![];
+        let mut options_buffer = vec![];
+        let mut raw_arguments = to_raw(&default_args(), &mut strings_buffer, &mut options_buffer);
+        let _locked = setup_get_default_java_vm_init_args_call(GetDefaultJavaVMInitArgsCall::new(
+            &mut raw_arguments.raw_arguments as *mut jni_sys::JavaVMInitArgs as *mut c_void,
+        ));
+        assert_eq!(InitArguments::get_default(JniVersion::V1), None);
+        check_arguments(JniVersion::V1);
+    }
+
+    #[test]
+    fn get_default_or_closest_supported() {
+        let mut strings_buffer = vec![];
+        let mut options_buffer = vec![];
+        let mut raw_arguments = to_raw(&default_args(), &mut strings_buffer, &mut options_buffer);
+        let _locked = setup_get_default_java_vm_init_args_call(GetDefaultJavaVMInitArgsCall::new(
+            &mut raw_arguments.raw_arguments as *mut jni_sys::JavaVMInitArgs as *mut c_void,
+        ));
+        assert_eq!(
+            InitArguments::get_default_or_closest_supported(JniVersion::V1),
+            InitArguments {
+                version: JniVersion::V4,
+                options: resulting_options(),
+                ignore_unrecognized: false
+            }
+        );
+        check_arguments(JniVersion::V1);
+    }
+
+    #[test]
+    fn get_latest_default() {
+        let mut strings_buffer = vec![];
+        let mut options_buffer = vec![];
+        let mut raw_arguments = to_raw(&default_args(), &mut strings_buffer, &mut options_buffer);
+        let _locked = setup_get_default_java_vm_init_args_call(GetDefaultJavaVMInitArgsCall::new(
+            &mut raw_arguments.raw_arguments as *mut jni_sys::JavaVMInitArgs as *mut c_void,
+        ));
+        assert_eq!(
+            InitArguments::get_latest_default(),
+            InitArguments {
+                version: JniVersion::V4,
+                options: resulting_options(),
+                ignore_unrecognized: false
+            }
+        );
+        check_arguments(JniVersion::V8);
+    }
+
+    #[test]
+    fn with_options() {
+        let arguments = InitArguments {
+            version: JniVersion::V4,
+            options: vec![JvmOption::CheckedJni],
+            ignore_unrecognized: false,
+        };
+        assert_eq!(
+            arguments.with_options(&[
+                JvmOption::Verbose(JvmVerboseOption::Gc),
+                JvmOption::Unknown("test".to_owned()),
+            ]),
+            InitArguments {
+                version: JniVersion::V4,
+                options: vec![
+                    JvmOption::CheckedJni,
+                    JvmOption::Verbose(JvmVerboseOption::Gc),
+                    JvmOption::Unknown("test".to_owned()),
+                ],
+                ignore_unrecognized: false,
+            }
+        );
+    }
+
+    #[test]
+    fn with_option() {
+        let arguments = InitArguments {
+            version: JniVersion::V4,
+            options: vec![JvmOption::CheckedJni],
+            ignore_unrecognized: false,
+        };
+        assert_eq!(
+            arguments.with_option(JvmOption::Verbose(JvmVerboseOption::Gc)),
+            InitArguments {
+                version: JniVersion::V4,
+                options: vec![
+                    JvmOption::CheckedJni,
+                    JvmOption::Verbose(JvmVerboseOption::Gc),
+                ],
+                ignore_unrecognized: false,
+            }
+        );
+    }
+
+    #[test]
+    fn unchecked() {
+        let arguments = InitArguments {
+            version: JniVersion::V4,
+            options: vec![
+                JvmOption::Verbose(JvmVerboseOption::Gc),
+                JvmOption::CheckedJni,
+            ],
+            ignore_unrecognized: false,
+        };
+        assert_eq!(
+            arguments.unchecked(),
+            InitArguments {
+                version: JniVersion::V4,
+                options: vec![JvmOption::Verbose(JvmVerboseOption::Gc)],
+                ignore_unrecognized: false,
+            }
+        );
+    }
+
+    #[test]
+    fn checked() {
+        let arguments = InitArguments {
+            version: JniVersion::V4,
+            options: vec![JvmOption::Verbose(JvmVerboseOption::Gc)],
+            ignore_unrecognized: false,
+        };
+        assert_eq!(
+            arguments.checked(),
+            InitArguments {
+                version: JniVersion::V4,
+                options: vec![
+                    JvmOption::Verbose(JvmVerboseOption::Gc),
+                    JvmOption::CheckedJni,
+                ],
+                ignore_unrecognized: false,
+            }
+        );
+    }
+
+    #[test]
+    fn ignoring_unrecognized_options() {
+        let arguments = InitArguments {
+            version: JniVersion::V4,
+            options: vec![],
+            ignore_unrecognized: false,
+        };
+        assert_eq!(
+            arguments.ignoring_unrecognized_options(),
+            InitArguments {
+                version: JniVersion::V4,
+                options: vec![],
+                ignore_unrecognized: true,
+            }
+        );
+    }
+
+    #[test]
+    fn failing_on_unrecognized_options() {
+        let arguments = InitArguments {
+            version: JniVersion::V4,
+            options: vec![],
+            ignore_unrecognized: true,
+        };
+        assert_eq!(
+            arguments.failing_on_unrecognized_options(),
+            InitArguments {
+                version: JniVersion::V4,
+                options: vec![],
+                ignore_unrecognized: false,
+            }
+        );
+    }
+
+    #[test]
+    fn version() {
+        let arguments = InitArguments {
+            version: JniVersion::V4,
+            options: vec![],
+            ignore_unrecognized: true,
+        };
+        assert_eq!(arguments.version(), JniVersion::V4);
+    }
+}
+
+// TODO: move to a separate library.
+fn to_bool(value: jni_sys::jboolean) -> bool {
+    match value {
+        jni_sys::JNI_TRUE => true,
+        jni_sys::JNI_FALSE => false,
+        value => panic!("Unexpected jboolean value {}", value),
+    }
+}
+
+fn from_bool(value: bool) -> jni_sys::jboolean {
+    match value {
+        true => jni_sys::JNI_TRUE,
+        false => jni_sys::JNI_FALSE,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,15 @@
 extern crate cesu8;
 extern crate jni_sys;
+#[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
 
 mod attach_arguments;
+mod init_arguments;
 mod java_string;
+mod raw;
 mod version;
 
 pub use attach_arguments::AttachArguments;
+pub use init_arguments::{InitArguments, JvmOption, JvmVerboseOption};
 pub use version::JniVersion;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,107 @@
+#![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
+
+/// This is a module that wraps `jni_sys` in a way that allows mocking it's functions
+/// for unit testing. It defines two versions of each function: a prod one that is just
+/// a shallow proxy and a test one, that comes with global variables for
+/// mocking the result and the arguments. Tests should populate these variables and then
+/// execute the code that depends of these functions.
+use jni_sys;
+use std::os::raw::c_void;
+
+#[cfg(not(test))]
+pub unsafe fn JNI_GetDefaultJavaVMInitArgs(arguments: *mut c_void) -> jni_sys::jint {
+    jni_sys::JNI_GetDefaultJavaVMInitArgs(arguments)
+}
+
+#[cfg(test)]
+use std::ptr;
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard};
+
+#[cfg(test)]
+pub struct SendPtr<T>(pub *mut T);
+
+// Safe to share in tests.
+#[cfg(test)]
+unsafe impl<T> Send for SendPtr<T> {}
+
+#[cfg(test)]
+pub struct GetDefaultJavaVMInitArgsCall {
+    input: Option<jni_sys::JavaVMInitArgs>,
+    result: jni_sys::jint,
+    set_input: SendPtr<c_void>,
+}
+
+// Safe for single-threaded tests.
+#[cfg(test)]
+unsafe impl Send for GetDefaultJavaVMInitArgsCall {}
+
+#[cfg(test)]
+impl GetDefaultJavaVMInitArgsCall {
+    fn empty() -> Self {
+        GetDefaultJavaVMInitArgsCall {
+            input: None,
+            result: 17,
+            set_input: SendPtr(ptr::null_mut()),
+        }
+    }
+
+    pub fn new(set_input: *mut c_void) -> Self {
+        GetDefaultJavaVMInitArgsCall {
+            input: None,
+            result: 17,
+            set_input: SendPtr(set_input),
+        }
+    }
+}
+
+#[cfg(test)]
+lazy_static! {
+    static ref TEST_JNI_GetDefaultJavaVMInitArgs: Mutex<GetDefaultJavaVMInitArgsCall> =
+        Mutex::new(GetDefaultJavaVMInitArgsCall::empty());
+    static ref TEST_JNI_GetDefaultJavaVMInitArgs_Lock: Mutex<bool> = Mutex::new(false);
+}
+
+#[cfg(test)]
+/// Mock a call to the `JNI_GetDefaultJavaVMInitArgs` JNI function.
+/// Returns a `MutexGuard` which is used to make tests using this function sequential,
+/// which is required because of the use of global mutable variables.
+pub fn setup_get_default_java_vm_init_args_call(
+    call: GetDefaultJavaVMInitArgsCall,
+) -> MutexGuard<'static, bool> {
+    // Tests for code that calls JNI_GetDefaultJavaVMInitArgs  must be single-threaded
+    // because global mock variables are not thread-safe.
+    let lock = TEST_JNI_GetDefaultJavaVMInitArgs_Lock.lock().unwrap();
+    *TEST_JNI_GetDefaultJavaVMInitArgs.lock().unwrap() = call;
+    lock
+}
+
+#[cfg(test)]
+pub fn get_default_java_vm_init_args_call_input() -> jni_sys::JavaVMInitArgs {
+    TEST_JNI_GetDefaultJavaVMInitArgs
+        .lock()
+        .unwrap()
+        .input
+        .unwrap()
+}
+
+#[cfg(test)]
+pub unsafe fn JNI_GetDefaultJavaVMInitArgs(arguments: *mut c_void) -> jni_sys::jint {
+    let arguments = arguments as *mut jni_sys::JavaVMInitArgs;
+    TEST_JNI_GetDefaultJavaVMInitArgs.lock().unwrap().input = Some(*arguments);
+    if TEST_JNI_GetDefaultJavaVMInitArgs
+        .lock()
+        .unwrap()
+        .set_input
+        .0 != ptr::null_mut()
+    {
+        let test_value = TEST_JNI_GetDefaultJavaVMInitArgs
+            .lock()
+            .unwrap()
+            .set_input
+            .0 as *mut jni_sys::JavaVMInitArgs;
+        *arguments = *test_value;
+    }
+    TEST_JNI_GetDefaultJavaVMInitArgs.lock().unwrap().result
+}

--- a/tests/init_arguments.rs
+++ b/tests/init_arguments.rs
@@ -1,0 +1,38 @@
+extern crate rust_jni;
+
+#[cfg(test)]
+mod default_jvm_arguments {
+    #[test]
+    fn supported_versions() {
+        use rust_jni::{InitArguments, JniVersion};
+        assert_eq!(
+            InitArguments::get_default_or_closest_supported(JniVersion::V1).version(),
+            JniVersion::V2
+        );
+        assert_eq!(
+            InitArguments::get_default_or_closest_supported(JniVersion::V2).version(),
+            JniVersion::V2
+        );
+        assert_eq!(
+            InitArguments::get_default_or_closest_supported(JniVersion::V4).version(),
+            JniVersion::V4
+        );
+        assert_eq!(
+            InitArguments::get_default_or_closest_supported(JniVersion::V6).version(),
+            JniVersion::V6
+        );
+        assert_eq!(
+            InitArguments::get_default_or_closest_supported(JniVersion::V8).version(),
+            JniVersion::V8
+        );
+    }
+
+    #[test]
+    fn latest_version() {
+        use rust_jni::{InitArguments, JniVersion};
+        assert_eq!(
+            InitArguments::get_latest_default().version(),
+            JniVersion::V8
+        );
+    }
+}


### PR DESCRIPTION
The type uses JNI global JNI_GetDefaultJavaVMInitArgs function and so requires to link to libjvm. Because of this, this PR adds a build script for finding it.

Mocking and verifying calls to global functions is not easy in Rust. To do that with JNI functions this PR includes a `raw` module that is supposed to proxy global function calls to the `jni_sys` package in prod and provide a way to mock them in tests.