### PR TITLE
Add `version` filed to `AttachArguments`.

### DIFF
--- a/src/attach_arguments.rs
+++ b/src/attach_arguments.rs
@@ -1,3 +1,4 @@
+use init_arguments::InitArguments;
 use java_string::*;
 use jni_sys;
 use std::marker::PhantomData;
@@ -10,6 +11,7 @@ use version::{self, JniVersion};
 /// [JNI documentation](https://docs.oracle.com/javase/10/docs/specs/jni/invocation.html#attachcurrentthread)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttachArguments<'a> {
+    version: JniVersion,
     thread_name: Option<&'a str>,
     // TODO(#7): support thread groups.
 }
@@ -18,59 +20,81 @@ impl<'a> AttachArguments<'a> {
     /// Create attach arguments with the default thread name.
     ///
     /// [JNI documentation](https://docs.oracle.com/javase/10/docs/specs/jni/invocation.html#attachcurrentthread)
-    pub fn new() -> Self {
-        AttachArguments { thread_name: None }
+    pub fn new(init_arguments: &InitArguments) -> Self {
+        AttachArguments {
+            thread_name: None,
+            version: init_arguments.version(),
+        }
     }
 
     /// Create attach arguments with a specified thread name.
     ///
     /// [JNI documentation](https://docs.oracle.com/javase/10/docs/specs/jni/invocation.html#attachcurrentthread)
-    pub fn named(thread_name: &'a str) -> Self {
+    pub fn named(init_arguments: &InitArguments, thread_name: &'a str) -> Self {
         AttachArguments {
             thread_name: Some(thread_name),
+            version: init_arguments.version(),
         }
+    }
+
+    /// Return the JNI version this arguments will request when attaching a thread to a Java VM.
+    pub fn version(&self) -> JniVersion {
+        self.version
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::AttachArguments;
+    use super::*;
+    use init_arguments;
 
     #[test]
     fn new() {
+        let init_arguments = init_arguments::new(JniVersion::V4);
         assert_eq!(
-            AttachArguments::new(),
-            AttachArguments { thread_name: None }
+            AttachArguments::new(&init_arguments),
+            AttachArguments {
+                thread_name: None,
+                version: JniVersion::V4
+            }
         );
     }
 
     #[test]
     fn named() {
+        let init_arguments = init_arguments::new(JniVersion::V4);
         assert_eq!(
-            AttachArguments::named("test-name"),
+            AttachArguments::named(&init_arguments, "test-name"),
             AttachArguments {
-                thread_name: Some("test-name")
+                thread_name: Some("test-name"),
+                version: JniVersion::V4,
             }
         );
+    }
+
+    #[test]
+    fn version() {
+        let arguments = AttachArguments {
+            version: JniVersion::V4,
+            thread_name: None,
+        };
+        assert_eq!(arguments.version(), JniVersion::V4);
     }
 }
 
 /// A wrapper around `jni_sys::JavaVMAttachArgs` with a lifetime to ensure
 /// there's no access to freed memory.
 pub struct RawAttachArguments<'a> {
-    raw_arguments: jni_sys::JavaVMAttachArgs,
+    pub raw_arguments: jni_sys::JavaVMAttachArgs,
+    #[allow(dead_code)]
     buffer_len: usize,
     _buffer: PhantomData<&'a Vec<u8>>,
 }
 
 /// Convert `AttachArguments` to `jni_sys::JavaVMAttachArgs`. Uses a buffer for storing
 /// the Java string with the thread name.
-pub fn to_raw<'a>(
-    arguments: &AttachArguments,
-    version: JniVersion,
-    buffer: &'a mut Vec<u8>,
-) -> RawAttachArguments<'a> {
-    let version = version::to_raw(version);
+pub fn to_raw<'a>(arguments: &AttachArguments, buffer: &'a mut Vec<u8>) -> RawAttachArguments<'a> {
+    let version = version::to_raw(arguments.version);
     let group = ptr::null_mut();
     let raw_arguments = jni_sys::JavaVMAttachArgs {
         name: match arguments.thread_name {
@@ -93,13 +117,15 @@ pub fn to_raw<'a>(
 #[cfg(test)]
 mod to_raw_tests {
     use super::*;
+    use init_arguments;
     use std::slice;
 
     #[test]
     fn to_raw() {
-        let arguments = AttachArguments::new();
+        let init_arguments = init_arguments::new(JniVersion::V8);
+        let arguments = AttachArguments::new(&init_arguments);
         let mut buffer: Vec<u8> = vec![];
-        let raw_arguments = super::to_raw(&arguments, JniVersion::V8, &mut buffer);
+        let raw_arguments = super::to_raw(&arguments, &mut buffer);
         assert_eq!(raw_arguments.raw_arguments.group, ptr::null_mut());
         assert_eq!(raw_arguments.raw_arguments.name, ptr::null_mut());
         assert_eq!(
@@ -110,10 +136,11 @@ mod to_raw_tests {
 
     #[test]
     fn to_raw_named() {
+        let init_arguments = init_arguments::new(JniVersion::V8);
         let test_name = "test-name";
-        let arguments = AttachArguments::named(test_name);
+        let arguments = AttachArguments::named(&init_arguments, test_name);
         let mut buffer: Vec<u8> = vec![];
-        let raw_arguments = super::to_raw(&arguments, JniVersion::V8, &mut buffer);
+        let raw_arguments = super::to_raw(&arguments, &mut buffer);
         assert_eq!(raw_arguments.raw_arguments.group, ptr::null_mut());
         assert_eq!(
             raw_arguments.raw_arguments.version,

--- a/src/init_arguments.rs
+++ b/src/init_arguments.rs
@@ -438,6 +438,15 @@ pub unsafe fn from_raw(raw_arguments: &jni_sys::JavaVMInitArgs) -> InitArguments
 }
 
 #[cfg(test)]
+pub fn new(version: JniVersion) -> InitArguments {
+    InitArguments {
+        version: version,
+        options: vec![],
+        ignore_unrecognized: true,
+    }
+}
+
+#[cfg(test)]
 pub mod tests {
     use super::*;
 
@@ -701,7 +710,7 @@ pub mod tests {
 }
 
 // TODO: move to a separate library.
-fn to_bool(value: jni_sys::jboolean) -> bool {
+pub fn to_bool(value: jni_sys::jboolean) -> bool {
     match value {
         jni_sys::JNI_TRUE => true,
         jni_sys::JNI_FALSE => false,


### PR DESCRIPTION
A JNI version is needed for atttaching a thread to a Java VM.

To ensure the version is supported, it can be only extracted from an `InitArguments` value.