### PR TITLE
Change semantics of the Exception token.

### DIFF
--- a/tests/classes.rs
+++ b/tests/classes.rs
@@ -1,0 +1,19 @@
+extern crate rust_jni;
+
+#[cfg(test)]
+mod classes {
+    use rust_jni::*;
+
+    #[test]
+    fn test() {
+        let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
+        let vm = JavaVM::create(&init_arguments).unwrap();
+        let env = vm.attach(&AttachArguments::new(&init_arguments)).unwrap();
+        let token = env.token();
+
+        // TODO: compare to the `java::lang::String::class()` result.
+        let _class = java::lang::Class::find(&env, "java/lang/String", &token).unwrap();
+        // TODO: check the message.
+        let _exception = java::lang::Class::find(&env, "java/lang/Invalid", &token).unwrap_err();
+    }
+}


### PR DESCRIPTION
Now if the `Exception` token is present there MUST be a pending exception. This makes the code much simpler and I don't think there is actually a case when this is not true. But even if there is, we can always check for the exception manually.

This PR also introduces the `JavaResult` type, reimplements `Class::find` with it and adds an integration test that searches for different classes.