### PR TITLE
Basic String manipulation methods.

### DIFF
--- a/src/testing.rs
+++ b/src/testing.rs
@@ -21,6 +21,8 @@ pub fn empty_raw_java_vm() -> jni_sys::JNIInvokeInterface_ {
 
 #[cfg(test)]
 pub fn empty_raw_jni_env() -> jni_sys::JNINativeInterface_ {
+    unsafe extern "system" fn delete_local_ref(_: *mut jni_sys::JNIEnv, _: jni_sys::jobject) {}
+
     jni_sys::JNINativeInterface_ {
         reserved0: ptr::null_mut(),
         reserved1: ptr::null_mut(),
@@ -45,7 +47,8 @@ pub fn empty_raw_jni_env() -> jni_sys::JNINativeInterface_ {
         PopLocalFrame: None,
         NewGlobalRef: None,
         DeleteGlobalRef: None,
-        DeleteLocalRef: None,
+        // To not fail during the destructor call.
+        DeleteLocalRef: Some(delete_local_ref),
         IsSameObject: None,
         NewLocalRef: None,
         EnsureLocalCapacity: None,

--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -1,0 +1,27 @@
+extern crate rust_jni;
+
+#[cfg(test)]
+mod strings {
+    use rust_jni::*;
+
+    #[test]
+    fn test() {
+        let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
+        let vm = JavaVM::create(&init_arguments).unwrap();
+        let env = vm.attach(&AttachArguments::new(&init_arguments)).unwrap();
+        let token = env.token();
+
+        assert_eq!(
+            java::lang::String::empty(&env, &token)
+                .unwrap()
+                .as_string(&token),
+            ""
+        );
+        assert_eq!(
+            java::lang::String::new(&env, "test-string", &token)
+                .unwrap()
+                .as_string(&token),
+            "test-string"
+        );
+    }
+}


### PR DESCRIPTION
Also make an empty DeleteLocalRef a default to not use `mem::forget` as much.