### PR TITLE
Allow not specifying `extends java.lang.Object`.

### DIFF
--- a/generator/tests/test.rs
+++ b/generator/tests/test.rs
@@ -23,7 +23,7 @@ mod a {
             public interface a.b.TestInterface3 {}
             public interface a.b.TestInterface4 extends a.b.TestInterface2, a.b.TestInterface3 {}
 
-            public class a.b.TestClass1 extends java.lang.Object {}
+            public class a.b.TestClass1 {}
             public class a.b.TestClass2 extends a.b.TestClass1 implements a.b.TestInterface1, a.b.TestInterface3 {}
         }
 


### PR DESCRIPTION
Related to #76.