### PR TITLE
Parse Java definitions metadata.

### DIFF
--- a/generator/tests/test.rs
+++ b/generator/tests/test.rs
@@ -10,20 +10,40 @@ mod java {
 }
 
 #[cfg(test)]
+mod c {
+    pub mod d {
+        #[allow(unused_imports)]
+        use rust_jni_generator::*;
+
+        java_generate! {
+            public interface c.d.TestInterface1 {}
+            public interface c.d.TestInterface2 extends c.d.TestInterface1 {}
+
+            public class c.d.TestClass1 {}
+            public class c.d.TestClass2 extends c.d.TestClass1 implements c.d.TestInterface1 {}
+        }
+    }
+}
+
+#[cfg(test)]
 mod a {
     mod b {
         #[allow(unused_imports)]
         use rust_jni_generator::*;
 
         java_generate! {
-            public interface a.b.TestInterface1 {}
-            public interface a.b.TestInterface2 extends a.b.TestInterface1 {}
             public interface a.b.TestInterface3 {}
-            public interface a.b.TestInterface4 extends a.b.TestInterface2, a.b.TestInterface3 {}
+            public interface a.b.TestInterface4 extends c.d.TestInterface2, a.b.TestInterface3 {}
 
-            public class a.b.TestClass1 {}
-            public class a.b.TestClass2 extends a.b.TestClass1 implements a.b.TestInterface1 {}
-            public class a.b.TestClass3 extends a.b.TestClass2 implements a.b.TestInterface1, a.b.TestInterface4 {}
+            public class a.b.TestClass3 extends c.d.TestClass2 implements c.d.TestInterface1, a.b.TestInterface4 {}
+
+            metadata {
+                interface c.d.TestInterface1 {}
+                interface c.d.TestInterface2 extends c.d.TestInterface1 {}
+
+                class c.d.TestClass1;
+                class c.d.TestClass2 extends c.d.TestClass1 implements c.d.TestInterface1;
+            }
         }
     }
 }


### PR DESCRIPTION
Needed for building object hierarchy for classes in different modules.

Related to #76.