### PR TITLE
Remove Java conversions for return type and arguments in native method wrappers.

### DIFF
--- a/rust-jni/src/java_primitives.rs
+++ b/rust-jni/src/java_primitives.rs
@@ -8,7 +8,6 @@ use crate::java_methods::JniSignature;
 use crate::jni_bool;
 use crate::jni_methods;
 use crate::jni_types::private::JniPrimitiveType;
-use crate::native_method::FromNativeArgument;
 use crate::result::JavaResult;
 use crate::token::NoException;
 use std::char;
@@ -107,18 +106,6 @@ macro_rules! jni_primitive_argument_traits {
             #[inline(always)]
             fn to_jni(&self) -> Self::JniType {
                 *self as Self::JniType
-            }
-        }
-
-        impl FromNativeArgument for $type {
-            type ResultType = Self;
-
-            #[inline(always)]
-            unsafe fn from_jni_argument<'a>(
-                _env: &'a JniEnv<'a>,
-                value: Self::JniType,
-            ) -> Self::ResultType {
-                <Self as JavaPrimitiveResultType>::from_jni(value)
             }
         }
     };

--- a/rust-jni/src/native_method.rs
+++ b/rust-jni/src/native_method.rs
@@ -1,10 +1,6 @@
 use crate::class::Class;
 use crate::env::JniEnv;
 use crate::error::JniError;
-use crate::java_class::JavaClass;
-use crate::java_methods::JavaArgumentTuple;
-use crate::java_methods::JavaArgumentType;
-use crate::java_methods::JavaMethodSignature;
 use crate::java_string::to_java_string_null_terminated;
 use crate::jni_types::private::JniArgumentTypeTuple;
 use crate::jni_types::private::JniType;
@@ -13,105 +9,9 @@ use crate::result::JavaResult;
 use crate::token::NoException;
 use crate::vm::JavaVMRef;
 use jni_sys;
-use std::alloc;
 use std::mem;
 use std::panic;
 use std::ptr::{self, NonNull};
-
-/// A trait implemented for all types that can be results of native Java methods.
-///
-/// These are all primitive JNI types, [`()`](https://doc.rust-lang.org/stable/std/primitive.unit.html) and
-/// Java class wrappers.
-pub trait NativeMethodResult {
-    type JniType: JniType;
-
-    fn to_jni(&self) -> Self::JniType;
-}
-
-impl<T> NativeMethodResult for T
-where
-    T: JavaArgumentType,
-{
-    type JniType = <Self as JavaArgumentType>::JniType;
-
-    #[inline(always)]
-    fn to_jni(&self) -> Self::JniType {
-        JavaArgumentType::to_jni(self)
-    }
-}
-
-impl NativeMethodResult for () {
-    type JniType = ();
-
-    #[inline(always)]
-    fn to_jni(&self) -> Self::JniType {
-        *self
-    }
-}
-
-pub trait FromNativeArgument: JavaArgumentType {
-    type ResultType;
-
-    unsafe fn from_jni_argument<'a>(env: &'a JniEnv<'a>, value: Self::JniType) -> Self::ResultType;
-}
-
-impl<T> FromNativeArgument for T
-where
-    for<'a> T: JavaClass<'a>,
-{
-    type ResultType = Option<Self>;
-
-    #[inline(always)]
-    unsafe fn from_jni_argument<'a>(env: &'a JniEnv<'a>, value: Self::JniType) -> Self::ResultType {
-        NonNull::new(value).map(|value| Self::from_object(Object::from_raw(env, value)))
-    }
-}
-
-pub trait FromNativeArgumentTuple: JavaArgumentTuple {
-    type ResultType;
-
-    unsafe fn from_jni_argument<'a>(env: &'a JniEnv<'a>, value: Self::JniType) -> Self::ResultType;
-}
-
-macro_rules! peel_from_native_argument_tuple_impls {
-    () => ();
-    ($type:ident, $($other:ident,)*) => (from_native_argument_tuple_impls! { $($other,)* });
-}
-
-macro_rules! from_native_argument_tuple_impls {
-    ( $($type:ident,)*) => (
-        impl<$($type),*> FromNativeArgumentTuple for ($($type,)*)
-        where
-            $($type: FromNativeArgument,)*
-        {
-            type ResultType = ($($type::ResultType,)*);
-
-            #[inline(always)]
-            unsafe fn from_jni_argument<'a>(#[allow(unused_variables)] env: &'a JniEnv<'a>, value: Self::JniType) -> Self::ResultType {
-                #[allow(non_snake_case)]
-                let ($($type,)*) = value;
-                ($(<$type as FromNativeArgument>::from_jni_argument(env, $type),)*)
-            }
-        }
-
-        peel_from_native_argument_tuple_impls! { $($type,)* }
-    );
-}
-
-from_native_argument_tuple_impls! {
-    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-}
 
 /// Implementation of a static native Java method.
 ///
@@ -127,6 +27,7 @@ from_native_argument_tuple_impls! {
 /// # use rust_jni::*;
 /// # use rust_jni::java::lang::String;
 /// # use std::ptr;
+/// # use std::mem;
 /// #
 /// # fn main() {
 /// #     let init_arguments = InitArguments::default();
@@ -138,13 +39,14 @@ from_native_argument_tuple_impls! {
 /// #        },
 /// #     );
 /// # }
+/// #
 /// #[no_mangle]
 /// unsafe extern "C" fn Java_java_lang_String_valueOf__I(
 ///     raw_env: *mut jni_sys::JNIEnv,
 ///     raw_class: jni_sys::jclass,
 ///     raw_argument: jni_sys::jint,
 /// ) -> jni_sys::jstring {
-///     static_native_method_implementation::<_, _, _, fn(i32) -> String<'static>>(
+///     static_native_method_implementation(
 ///         raw_env,
 ///         raw_class,
 ///         (raw_argument,),
@@ -158,11 +60,15 @@ from_native_argument_tuple_impls! {
 ///                     .as_string(&token),
 ///                 "java.lang.String",
 ///             );
-///             let result = String::value_of_int(env, &token, *argument)
+///             let result = String::value_of_int(env, &token, argument as i32)
 ///                 .or_npe(env, &token)
 ///                 .unwrap();
 ///             assert_eq!(result.as_string(&token), "17");
-///             (Ok(Box::new(result)), token)
+///             // Safe because we only pass it to Java.
+///             let java_result = unsafe { result.raw_object() }.as_ptr();
+///             // We don't want to return a deleted reference to Java.
+///             mem::forget(result);
+///             (Ok(java_result), token)
 ///         }
 ///     )
 /// }
@@ -171,9 +77,9 @@ from_native_argument_tuple_impls! {
 /// # unsafe {
 /// let string_class = String::empty(env, &token)?.class(&token);
 /// let string = Java_java_lang_String_valueOf__I(
-///     string_class.env().raw_env().as_ptr(),
+///     env.raw_env().as_ptr(),
 ///     string_class.raw_object().as_ptr(),
-///     17,
+///     17 as jni_sys::jint,
 /// );
 /// assert_ne!(string, ptr::null_mut());
 /// # }
@@ -181,41 +87,83 @@ from_native_argument_tuple_impls! {
 /// # }
 /// ```
 ///
+/// Example with an exeption:
+/// ```
+/// # use rust_jni::*;
+/// # use rust_jni::java::lang::{String, Throwable};
+/// # use std::ptr;
+/// #
+/// # fn main() {
+/// #     let init_arguments = InitArguments::default();
+/// #     let vm = JavaVM::create(&init_arguments).unwrap();
+/// #     let _ = vm.with_attached(
+/// #        &AttachArguments::new(init_arguments.version()),
+/// #        |env: &JniEnv, token: NoException| {
+/// #            ((), jni_main(env, token).unwrap())
+/// #        },
+/// #     );
+/// # }
+/// #
+/// #[no_mangle]
+/// unsafe extern "C" fn Java_java_lang_String_valueOf__I(
+///     raw_env: *mut jni_sys::JNIEnv,
+///     raw_class: jni_sys::jclass,
+///     raw_argument: jni_sys::jint,
+/// ) -> jni_sys::jstring {
+///     static_native_method_implementation(
+///         raw_env,
+///         raw_class,
+///         (raw_argument,),
+///         |class, token, (argument,)| {
+///             let exception = Throwable::new(class.env(), &token).unwrap();
+///             (Err(exception), token)
+///         }
+///     )
+/// }
+///
+/// # fn jni_main<'a>(env: &'a JniEnv<'a>, token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
+/// # unsafe {
+/// let string_class = String::empty(env, &token)?.class(&token);
+/// let string = Java_java_lang_String_valueOf__I(
+///     env.raw_env().as_ptr(),
+///     string_class.raw_object().as_ptr(),
+///     17 as jni_sys::jint,
+/// );
+/// assert_eq!(string, ptr::null_mut());
+///
+/// let raw_env = env.raw_env().as_ptr();
+/// let jni_fn = ((**raw_env).ExceptionOccurred).unwrap();
+/// let throwable = jni_fn(raw_env);
+/// assert_ne!(throwable, ptr::null_mut());
+/// # }
+/// # Ok(token)
+/// # }
+/// ```
+///
 /// This function is unsafe because it is possible to pass an invalid [`JNIEnv`](../jni_sys/type.JNIEnv.html)
 /// pointer or an invalid [`jclass`](../jni_sys/type.jclass.html).
-pub unsafe fn static_native_method_implementation<R, A, F, S>(
+pub unsafe fn static_native_method_implementation<R, A, F>(
     raw_env: *mut jni_sys::JNIEnv,
     raw_class: jni_sys::jclass,
-    arguments: A::JniType,
+    raw_arguments: A,
     callback: F,
-) -> R::JniType
+) -> R
 where
     // TODO(monnoroch): find out how to do this without allocation.
     // See https://stackoverflow.com/questions/59003532/using-higher-ranked-trait-bounds-with-generics.
-    for<'a> F: FnOnce(
-            &'a Class<'a>,
-            NoException<'a>,
-            &'a A::ResultType,
-        ) -> (
-            JavaResult<'a, Box<dyn NativeMethodResult<JniType = R::JniType> + 'a>>,
-            NoException<'a>,
-        ) + std::panic::UnwindSafe,
-    R: NativeMethodResult,
-    A: FromNativeArgumentTuple,
-    <A as JavaArgumentTuple>::JniType: std::panic::UnwindSafe,
-    S: JavaMethodSignature<A, R>,
+    for<'a> F: FnOnce(&'a Class<'a>, NoException<'a>, A) -> (JavaResult<'a, R>, NoException<'a>)
+        + std::panic::UnwindSafe,
+    R: JniType,
+    A: JniArgumentTypeTuple + panic::UnwindSafe,
 {
-    generic_native_method_implementation::<R::JniType, A::JniType, _>(
+    generic_native_method_implementation::<R, A, _>(
         raw_env,
-        arguments,
+        raw_arguments,
         |env, token, arguments| {
             // Should not panic if the class pointer is valid.
             let class = Class::from_raw(&env, NonNull::new(raw_class).unwrap());
-            let arguments = <A as FromNativeArgumentTuple>::from_jni_argument(env, arguments);
-            let (result, token) = callback(&class, token, &arguments);
+            let (result, token) = callback(&class, token, arguments);
             let result = to_jni_type::<R>(result, token);
-            // We don't own argument references.
-            mem::forget(arguments);
             // We don't own the reference.
             mem::forget(class);
             result
@@ -235,7 +183,72 @@ where
 /// Example:
 /// ```
 /// # use rust_jni::*;
-/// # use rust_jni::java::lang::String;
+/// # use rust_jni::java::lang::{Object, String};
+/// # use std::ptr::{self, NonNull};
+/// # use std::mem;
+/// # use jni_sys;
+/// #
+/// # fn main() {
+/// #     let init_arguments = InitArguments::default();
+/// #     let vm = JavaVM::create(&init_arguments).unwrap();
+/// #     let _ = vm.with_attached(
+/// #        &AttachArguments::new(init_arguments.version()),
+/// #        |env: &JniEnv, token: NoException| {
+/// #            ((), jni_main(env, token).unwrap())
+/// #        },
+/// #     );
+/// # }
+/// #[no_mangle]
+/// unsafe extern "C" fn Java_java_lang_Object_equals__Ljava_lang_Object_2(
+///     raw_env: *mut jni_sys::JNIEnv,
+///     raw_object: jni_sys::jobject,
+///     raw_argument: jni_sys::jobject,
+/// ) -> jni_sys::jboolean {
+///     native_method_implementation(
+///         raw_env,
+///         raw_object,
+///         (raw_argument,),
+///         |object, token, (argument,)| {
+///             let env = object.env();
+///             let argument = NonNull::new(argument)
+///                 .map(|argument| unsafe {
+///                     String::from_object(Object::from_raw(env, argument))
+///                 })
+///                 .or_npe(env, &token)
+///                 .unwrap();
+///             let result = object.equals(&token, &argument).unwrap();
+///             // We don't own the reference.
+///             mem::forget(argument);
+///             let java_result = if result {
+///                 jni_sys::JNI_TRUE
+///             } else {
+///                 jni_sys::JNI_FALSE
+///             };
+///             (Ok(java_result), token)
+///         }
+///     )
+/// }
+///
+/// # fn jni_main<'a>(env: &'a JniEnv<'a>, token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
+/// # unsafe {
+/// let string1 = String::empty(env, &token)?;
+/// let string2 = String::new(env, &token, "")?;
+/// let equals = Java_java_lang_Object_equals__Ljava_lang_Object_2(
+///     env.raw_env().as_ptr(),
+///     string1.raw_object().as_ptr(),
+///     string2.raw_object().as_ptr(),
+/// );
+/// assert_eq!(equals, jni_sys::JNI_TRUE);
+/// # }
+/// # Ok(token)
+/// # }
+/// ```
+///
+/// Example with an exception:
+/// ```
+/// # use rust_jni::*;
+/// # use rust_jni::java::lang::{String, Throwable};
+/// # use jni_sys;
 /// # use std::ptr;
 /// #
 /// # fn main() {
@@ -249,44 +262,37 @@ where
 /// #     );
 /// # }
 /// #[no_mangle]
-/// unsafe extern "C" fn Java_java_lang_String_valueOf__I(
+/// unsafe extern "C" fn Java_java_lang_Object_equals__Ljava_lang_Object_2(
 ///     raw_env: *mut jni_sys::JNIEnv,
 ///     raw_object: jni_sys::jobject,
-///     raw_argument: jni_sys::jint,
-/// ) -> jni_sys::jstring {
-///     native_method_implementation::<_, _, _, fn(i32) -> String<'static>>(
+///     raw_argument: jni_sys::jobject,
+/// ) -> jni_sys::jboolean {
+///     native_method_implementation(
 ///         raw_env,
 ///         raw_object,
 ///         (raw_argument,),
 ///         |object, token, (argument,)| {
-///             let env = object.env();
-///             assert_eq!(
-///                 object
-///                     .class(&token)
-///                     .get_name(&token)
-///                     .or_npe(env, &token)
-///                     .unwrap()
-///                     .as_string(&token),
-///                 "java.lang.String",
-///             );
-///             let result = String::value_of_int(env, &token, *argument)
-///                 .or_npe(env, &token)
-///                 .unwrap();
-///             assert_eq!(result.as_string(&token), "17");
-///             (Ok(Box::new(result)), token)
+///             let exception = Throwable::new(object.env(), &token).unwrap();
+///             (Err(exception), token)
 ///         }
 ///     )
 /// }
 ///
 /// # fn jni_main<'a>(env: &'a JniEnv<'a>, token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
 /// # unsafe {
-/// let string = String::empty(env, &token)?;
-/// let string = Java_java_lang_String_valueOf__I(
-///     string.env().raw_env().as_ptr(),
-///     string.raw_object().as_ptr(),
-///     17,
+/// let string1 = String::empty(env, &token)?;
+/// let string2 = String::new(env, &token, "")?;
+/// let equals = Java_java_lang_Object_equals__Ljava_lang_Object_2(
+///     env.raw_env().as_ptr(),
+///     string1.raw_object().as_ptr(),
+///     string2.raw_object().as_ptr(),
 /// );
-/// assert_ne!(string, ptr::null_mut());
+/// assert_eq!(equals, jni_sys::JNI_FALSE);
+///
+/// let raw_env = env.raw_env().as_ptr();
+/// let jni_fn = ((**raw_env).ExceptionOccurred).unwrap();
+/// let throwable = jni_fn(raw_env);
+/// assert_ne!(throwable, ptr::null_mut());
 /// # }
 /// # Ok(token)
 /// # }
@@ -294,39 +300,28 @@ where
 ///
 /// This function is unsafe because it is possible to pass an invalid [`JNIEnv`](../jni_sys/type.JNIEnv.html)
 /// pointer or an invalid [`jobject`](../jni_sys/type.jobject.html).
-pub unsafe fn native_method_implementation<R, A, F, S>(
+pub unsafe fn native_method_implementation<R, A, F>(
     raw_env: *mut jni_sys::JNIEnv,
     raw_object: jni_sys::jobject,
-    arguments: A::JniType,
+    raw_arguments: A,
     callback: F,
-) -> R::JniType
+) -> R
 where
     // TODO(monnoroch): find out how to do this without allocation.
     // See https://stackoverflow.com/questions/59003532/using-higher-ranked-trait-bounds-with-generics.
-    for<'a> F: FnOnce(
-            &'a Object<'a>,
-            NoException<'a>,
-            &'a A::ResultType,
-        ) -> (
-            JavaResult<'a, Box<dyn NativeMethodResult<JniType = R::JniType> + 'a>>,
-            NoException<'a>,
-        ) + std::panic::UnwindSafe,
-    R: NativeMethodResult,
-    A: FromNativeArgumentTuple,
-    <A as JavaArgumentTuple>::JniType: std::panic::UnwindSafe,
-    S: JavaMethodSignature<A, R>,
+    for<'a> F: FnOnce(&'a Object<'a>, NoException<'a>, A) -> (JavaResult<'a, R>, NoException<'a>)
+        + std::panic::UnwindSafe,
+    R: JniType,
+    A: JniArgumentTypeTuple + panic::UnwindSafe,
 {
-    generic_native_method_implementation::<R::JniType, A::JniType, _>(
+    generic_native_method_implementation::<R, A, _>(
         raw_env,
-        arguments,
+        raw_arguments,
         |env, token, arguments| {
             // Should not panic if the class pointer is valid.
             let object = Object::from_raw(&env, NonNull::new(raw_object).unwrap());
-            let arguments = <A as FromNativeArgumentTuple>::from_jni_argument(env, arguments);
-            let (result, token) = callback(&object, token, &arguments);
+            let (result, token) = callback(&object, token, arguments);
             let result = to_jni_type::<R>(result, token);
-            // We don't own argument references.
-            mem::forget(arguments);
             // We don't own the reference.
             mem::forget(object);
             result
@@ -334,30 +329,20 @@ where
     )
 }
 
-fn to_jni_type<'a, R>(
-    result: JavaResult<'a, Box<dyn NativeMethodResult<JniType = R::JniType> + 'a>>,
-    token: NoException<'a>,
-) -> R::JniType
+fn to_jni_type<'a, R>(result: JavaResult<'a, R>, token: NoException<'a>) -> R
 where
-    R: NativeMethodResult + 'a,
+    R: JniType + 'a,
 {
     match result {
         Ok(result) => {
+            // The token is consumed.
             mem::forget(token);
-            let java_result = result.to_jni();
-            // Here we want to free memory of the Box, but don't want to run the destructor of the boxed value.
-            // Running the destructor for primitive types won't do anything, but running the destructor
-            // for a Java class wrapper will delete it's reference, which will make Java delete the object.
-            // Here we could use mem:;forget(result), but that would leak the Box-es memory, which we don't want.
-            let result = Box::into_raw(result);
-            // Safe because we just took ownership of this memory.
-            unsafe { alloc::dealloc(result as *mut u8, alloc::Layout::for_value(&*result)) };
-            java_result
+            result
         }
         #[cold]
         Err(exception) => {
             let _ = exception.throw(token);
-            R::JniType::default()
+            R::default()
         }
     }
 }

--- a/rust-jni/src/object.rs
+++ b/rust-jni/src/object.rs
@@ -141,9 +141,10 @@ impl<'env> Object<'env> {
 
     /// Construct from a raw pointer. Unsafe because an invalid pointer may be passed
     /// as the argument.
+    ///
     /// Unsafe because an incorrect object reference can be passed.
     #[inline(always)]
-    pub(crate) unsafe fn from_raw<'a>(
+    pub unsafe fn from_raw<'a>(
         env: &'a JniEnv<'a>,
         raw_object: NonNull<jni_sys::_jobject>,
     ) -> Object<'a> {


### PR DESCRIPTION
Currently conversion code is too ugly and not very performant and generic. Basically, a new design is needed.