### PR TITLE
Make tests single-threaded.

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -13,4 +13,4 @@ fi
 
 javac $javac_args examples/java-lib/java/rustjni/test/*.java
 
-cargo test $cargo_args
+cargo test $cargo_args -- --test-threads=1


### PR DESCRIPTION
`serial_test` does not fully solve the problem with flaky tests. I'm not sure why, but it just doesn't.