### PR TITLE
Remove the need to pass `JniEnv` everywhere.

### DIFF
--- a/examples/java-lib/src/class_with_object_methods.rs
+++ b/examples/java-lib/src/class_with_object_methods.rs
@@ -7,11 +7,8 @@ pub struct ClassWithObjectMethods<'a> {
 }
 
 impl<'a> ClassWithObjectMethods<'a> {
-    pub fn new(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-    ) -> JavaResult<'a, ClassWithObjectMethods<'a>> {
-        unsafe { call_constructor::<Self, _, fn()>(env, token, ()) }
+    pub fn new(token: &NoException<'a>) -> JavaResult<'a, ClassWithObjectMethods<'a>> {
+        unsafe { call_constructor::<Self, _, fn()>(token, ()) }
     }
 
     pub fn test_function_object(
@@ -31,14 +28,12 @@ impl<'a> ClassWithObjectMethods<'a> {
     }
 
     pub fn test_static_function_object(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         argument: impl JavaObjectArgument<'a, SimpleClass<'a>>,
     ) -> JavaResult<'a, Option<SimpleClass<'a>>> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(Option<&SimpleClass<'a>>) -> SimpleClass<'a>>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument.as_argument(),),

--- a/examples/java-lib/src/class_with_object_native_methods.rs
+++ b/examples/java-lib/src/class_with_object_native_methods.rs
@@ -8,11 +8,8 @@ pub struct ClassWithObjectNativeMethods<'a> {
 }
 
 impl<'a> ClassWithObjectNativeMethods<'a> {
-    pub fn new(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-    ) -> JavaResult<'a, ClassWithObjectNativeMethods<'a>> {
-        unsafe { call_constructor::<Self, _, fn()>(env, token, ()) }
+    pub fn new(token: &NoException<'a>) -> JavaResult<'a, ClassWithObjectNativeMethods<'a>> {
+        unsafe { call_constructor::<Self, _, fn()>(token, ()) }
     }
 
     pub fn test_function_object(
@@ -32,14 +29,12 @@ impl<'a> ClassWithObjectNativeMethods<'a> {
     }
 
     pub fn test_static_function_object(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         argument: impl JavaObjectArgument<'a, SimpleClass<'a>>,
     ) -> JavaResult<'a, Option<SimpleClass<'a>>> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(Option<&SimpleClass<'a>>) -> SimpleClass<'a>>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument.as_argument(),),
@@ -58,11 +53,9 @@ unsafe extern "C" fn Java_rustjni_test_ClassWithObjectNativeMethods_testNativeFu
         raw_env,
         raw_object,
         (argument,),
-        |object, token, (argument,)| {
+        |_object, token, (argument,)| {
             (
-                Ok(Box::new(
-                    argument.as_ref().or_npe(object.env(), &token).unwrap(),
-                )),
+                Ok(Box::new(argument.as_ref().or_npe(&token).unwrap())),
                 token,
             )
         },
@@ -79,11 +72,9 @@ unsafe extern "C" fn Java_rustjni_test_ClassWithObjectNativeMethods_testStaticNa
         raw_env,
         raw_class,
         (argument,),
-        |class, token, (argument,)| {
+        |_class, token, (argument,)| {
             (
-                Ok(Box::new(
-                    argument.as_ref().or_npe(class.env(), &token).unwrap(),
-                )),
+                Ok(Box::new(argument.as_ref().or_npe(&token).unwrap())),
                 token,
             )
         },

--- a/examples/java-lib/src/class_with_primitive_methods.rs
+++ b/examples/java-lib/src/class_with_primitive_methods.rs
@@ -6,11 +6,8 @@ pub struct ClassWithPrimitiveMethods<'a> {
 }
 
 impl<'a> ClassWithPrimitiveMethods<'a> {
-    pub fn new(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-    ) -> JavaResult<'a, ClassWithPrimitiveMethods<'a>> {
-        unsafe { call_constructor::<Self, _, fn()>(env, token, ()) }
+    pub fn new(token: &NoException<'a>) -> JavaResult<'a, ClassWithPrimitiveMethods<'a>> {
+        unsafe { call_constructor::<Self, _, fn()>(token, ()) }
     }
 
     pub fn test_function_void(&self, token: &NoException<'a>) -> JavaResult<'a, ()> {
@@ -93,23 +90,18 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
         }
     }
 
-    pub fn test_static_function_void(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-    ) -> JavaResult<'a, ()> {
+    pub fn test_static_function_void(token: &NoException<'a>) -> JavaResult<'a, ()> {
         // Safe because we ensure correct arguments and return type.
-        unsafe { call_static_method::<Self, _, _, fn()>(env, token, "testStaticFunction\0", ()) }
+        unsafe { call_static_method::<Self, _, _, fn()>(token, "testStaticFunction\0", ()) }
     }
 
     pub fn test_static_function_bool(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         argument: bool,
     ) -> JavaResult<'a, bool> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(bool) -> bool>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -118,14 +110,12 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
     }
 
     pub fn test_static_function_char(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         argument: char,
     ) -> JavaResult<'a, char> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(char) -> char>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -133,15 +123,10 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
         }
     }
 
-    pub fn test_static_function_u8(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: u8,
-    ) -> JavaResult<'a, u8> {
+    pub fn test_static_function_u8(token: &NoException<'a>, argument: u8) -> JavaResult<'a, u8> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(u8) -> u8>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -149,15 +134,10 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
         }
     }
 
-    pub fn test_static_function_i16(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: i16,
-    ) -> JavaResult<'a, i16> {
+    pub fn test_static_function_i16(token: &NoException<'a>, argument: i16) -> JavaResult<'a, i16> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(i16) -> i16>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -165,15 +145,10 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
         }
     }
 
-    pub fn test_static_function_i32(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: i32,
-    ) -> JavaResult<'a, i32> {
+    pub fn test_static_function_i32(token: &NoException<'a>, argument: i32) -> JavaResult<'a, i32> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(i32) -> i32>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -181,15 +156,10 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
         }
     }
 
-    pub fn test_static_function_i64(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: i64,
-    ) -> JavaResult<'a, i64> {
+    pub fn test_static_function_i64(token: &NoException<'a>, argument: i64) -> JavaResult<'a, i64> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(i64) -> i64>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -198,7 +168,6 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
     }
 
     pub fn test_static_function_f32(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         // TODO(#25): floating point numbers don't work properly.
         argument: f64,
@@ -207,7 +176,6 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
         unsafe {
             // TODO(#25): floating point numbers don't work properly.
             call_static_method::<Self, _, _, fn(f64) -> f32>(
-                env,
                 token,
                 "testStaticFloatFunction\0",
                 (argument,),
@@ -215,15 +183,10 @@ impl<'a> ClassWithPrimitiveMethods<'a> {
         }
     }
 
-    pub fn test_static_function_f64(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: f64,
-    ) -> JavaResult<'a, f64> {
+    pub fn test_static_function_f64(token: &NoException<'a>, argument: f64) -> JavaResult<'a, f64> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(f64) -> f64>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),

--- a/examples/java-lib/src/class_with_primitive_native_methods.rs
+++ b/examples/java-lib/src/class_with_primitive_native_methods.rs
@@ -7,11 +7,8 @@ pub struct ClassWithPrimitiveNativeMethods<'a> {
 }
 
 impl<'a> ClassWithPrimitiveNativeMethods<'a> {
-    pub fn new(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-    ) -> JavaResult<'a, ClassWithPrimitiveNativeMethods<'a>> {
-        unsafe { call_constructor::<Self, _, fn()>(env, token, ()) }
+    pub fn new(token: &NoException<'a>) -> JavaResult<'a, ClassWithPrimitiveNativeMethods<'a>> {
+        unsafe { call_constructor::<Self, _, fn()>(token, ()) }
     }
 
     pub fn test_function_void(&self, token: &NoException<'a>) -> JavaResult<'a, ()> {
@@ -94,23 +91,18 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
         }
     }
 
-    pub fn test_static_function_void(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-    ) -> JavaResult<'a, ()> {
+    pub fn test_static_function_void(token: &NoException<'a>) -> JavaResult<'a, ()> {
         // Safe because we ensure correct arguments and return type.
-        unsafe { call_static_method::<Self, _, _, fn()>(env, token, "testStaticFunction\0", ()) }
+        unsafe { call_static_method::<Self, _, _, fn()>(token, "testStaticFunction\0", ()) }
     }
 
     pub fn test_static_function_bool(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         argument: bool,
     ) -> JavaResult<'a, bool> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(bool) -> bool>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -119,14 +111,12 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
     }
 
     pub fn test_static_function_char(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         argument: char,
     ) -> JavaResult<'a, char> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(char) -> char>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -134,15 +124,10 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
         }
     }
 
-    pub fn test_static_function_u8(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: u8,
-    ) -> JavaResult<'a, u8> {
+    pub fn test_static_function_u8(token: &NoException<'a>, argument: u8) -> JavaResult<'a, u8> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(u8) -> u8>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -150,15 +135,10 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
         }
     }
 
-    pub fn test_static_function_i16(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: i16,
-    ) -> JavaResult<'a, i16> {
+    pub fn test_static_function_i16(token: &NoException<'a>, argument: i16) -> JavaResult<'a, i16> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(i16) -> i16>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -166,15 +146,10 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
         }
     }
 
-    pub fn test_static_function_i32(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: i32,
-    ) -> JavaResult<'a, i32> {
+    pub fn test_static_function_i32(token: &NoException<'a>, argument: i32) -> JavaResult<'a, i32> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(i32) -> i32>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -182,15 +157,10 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
         }
     }
 
-    pub fn test_static_function_i64(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: i64,
-    ) -> JavaResult<'a, i64> {
+    pub fn test_static_function_i64(token: &NoException<'a>, argument: i64) -> JavaResult<'a, i64> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(i64) -> i64>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),
@@ -199,7 +169,6 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
     }
 
     pub fn test_static_function_f32(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         // TODO(#25): floating point numbers don't work properly.
         argument: f64,
@@ -208,7 +177,6 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
         unsafe {
             // TODO(#25): floating point numbers don't work properly.
             call_static_method::<Self, _, _, fn(f64) -> f32>(
-                env,
                 token,
                 "testStaticFloatFunction\0",
                 (argument,),
@@ -216,15 +184,10 @@ impl<'a> ClassWithPrimitiveNativeMethods<'a> {
         }
     }
 
-    pub fn test_static_function_f64(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        argument: f64,
-    ) -> JavaResult<'a, f64> {
+    pub fn test_static_function_f64(token: &NoException<'a>, argument: f64) -> JavaResult<'a, f64> {
         // Safe because we ensure correct arguments and return type.
         unsafe {
             call_static_method::<Self, _, _, fn(f64) -> f64>(
-                env,
                 token,
                 "testStaticFunction\0",
                 (argument,),

--- a/examples/java-lib/src/simple_class.rs
+++ b/examples/java-lib/src/simple_class.rs
@@ -6,12 +6,8 @@ pub struct SimpleClass<'a> {
 }
 
 impl<'a> SimpleClass<'a> {
-    pub fn new(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        value: i32,
-    ) -> JavaResult<'a, SimpleClass<'a>> {
-        unsafe { call_constructor::<Self, _, fn(i32)>(env, token, (value,)) }
+    pub fn new(token: &NoException<'a>, value: i32) -> JavaResult<'a, SimpleClass<'a>> {
+        unsafe { call_constructor::<Self, _, fn(i32)>(token, (value,)) }
     }
 
     pub fn value_with_added(&self, token: &NoException<'a>, to_add: i32) -> JavaResult<'a, i32> {

--- a/examples/java-lib/src/simple_sub_class.rs
+++ b/examples/java-lib/src/simple_sub_class.rs
@@ -7,12 +7,8 @@ pub struct SimpleSubClass<'a> {
 }
 
 impl<'a> SimpleSubClass<'a> {
-    pub fn new(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        value: i32,
-    ) -> JavaResult<'a, SimpleSubClass<'a>> {
-        unsafe { call_constructor::<Self, _, fn(i32)>(env, token, (value,)) }
+    pub fn new(token: &NoException<'a>, value: i32) -> JavaResult<'a, SimpleSubClass<'a>> {
+        unsafe { call_constructor::<Self, _, fn(i32)>(token, (value,)) }
     }
 }
 

--- a/examples/java-lib/src/simple_sub_sub_class.rs
+++ b/examples/java-lib/src/simple_sub_sub_class.rs
@@ -8,12 +8,8 @@ pub struct SimpleSubSubClass<'a> {
 }
 
 impl<'a> SimpleSubSubClass<'a> {
-    pub fn new(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        value: i32,
-    ) -> JavaResult<'a, SimpleSubSubClass<'a>> {
-        unsafe { call_constructor::<Self, _, fn(i32)>(env, token, (value,)) }
+    pub fn new(token: &NoException<'a>, value: i32) -> JavaResult<'a, SimpleSubSubClass<'a>> {
+        unsafe { call_constructor::<Self, _, fn(i32)>(token, (value,)) }
     }
 }
 

--- a/examples/java-lib/src/sub_class_with_method_alias.rs
+++ b/examples/java-lib/src/sub_class_with_method_alias.rs
@@ -7,12 +7,8 @@ pub struct SubClassWithMethodAlias<'a> {
 }
 
 impl<'a> SubClassWithMethodAlias<'a> {
-    pub fn new(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        value: i32,
-    ) -> JavaResult<'a, SubClassWithMethodAlias<'a>> {
-        unsafe { call_constructor::<Self, _, fn(i32)>(env, token, (value,)) }
+    pub fn new(token: &NoException<'a>, value: i32) -> JavaResult<'a, SubClassWithMethodAlias<'a>> {
+        unsafe { call_constructor::<Self, _, fn(i32)>(token, (value,)) }
     }
 
     pub fn combine(

--- a/examples/java-lib/src/sub_class_with_method_override.rs
+++ b/examples/java-lib/src/sub_class_with_method_override.rs
@@ -8,11 +8,10 @@ pub struct SubClassWithMethodOverride<'a> {
 
 impl<'a> SubClassWithMethodOverride<'a> {
     pub fn new(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         value: i32,
     ) -> JavaResult<'a, SubClassWithMethodOverride<'a>> {
-        unsafe { call_constructor::<Self, _, fn(i32)>(env, token, (value,)) }
+        unsafe { call_constructor::<Self, _, fn(i32)>(token, (value,)) }
     }
 }
 

--- a/examples/java-lib/src/sub_sub_class_with_method_alias.rs
+++ b/examples/java-lib/src/sub_sub_class_with_method_alias.rs
@@ -9,11 +9,10 @@ pub struct SubSubClassWithMethodAlias<'a> {
 
 impl<'a> SubSubClassWithMethodAlias<'a> {
     pub fn new(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         value: i32,
     ) -> JavaResult<'a, SubSubClassWithMethodAlias<'a>> {
-        unsafe { call_constructor::<Self, _, fn(i32)>(env, token, (value,)) }
+        unsafe { call_constructor::<Self, _, fn(i32)>(token, (value,)) }
     }
 
     pub fn combine(

--- a/examples/java-lib/src/sub_sub_class_with_method_override.rs
+++ b/examples/java-lib/src/sub_sub_class_with_method_override.rs
@@ -9,11 +9,10 @@ pub struct SubSubClassWithMethodOverride<'a> {
 
 impl<'a> SubSubClassWithMethodOverride<'a> {
     pub fn new(
-        env: &'a JniEnv<'a>,
         token: &NoException<'a>,
         value: i32,
     ) -> JavaResult<'a, SubSubClassWithMethodOverride<'a>> {
-        unsafe { call_constructor::<Self, _, fn(i32)>(env, token, (value,)) }
+        unsafe { call_constructor::<Self, _, fn(i32)>(token, (value,)) }
     }
 }
 

--- a/examples/java-lib/tests/method_alias.rs
+++ b/examples/java-lib/tests/method_alias.rs
@@ -11,10 +11,10 @@ mod test {
     use std::fs;
 
     macro_rules! assert_value_with_added_eq {
-        ($env:expr, $token:expr, $object:expr, $argument:expr, $value:expr, $expected:expr) => {{
+        ($token:expr, $object:expr, $argument:expr, $value:expr, $expected:expr) => {{
             let new_object = $object
                 .combine($token, $argument.unwrap())
-                .or_npe($env, $token)
+                .or_npe($token)
                 .unwrap();
             assert_eq!(
                 new_object.value_with_added($token, $value).unwrap(),
@@ -27,170 +27,146 @@ mod test {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let classes = vec![
-                    "SimpleClass",
-                    "SubClassWithMethodAlias",
-                    "SubSubClassWithMethodAlias",
-                ];
-                for class_name in classes {
-                    Class::define(
-                        env,
-                        &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
-                        &token,
-                    )
-                    .unwrap();
-                }
-
-                // Base class -- no aliasing.
-
-                let object = SimpleClass::new(env, &token, 12).unwrap();
-
-                assert_value_with_added_eq!(
-                    env,
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let classes = vec![
+                "SimpleClass",
+                "SubClassWithMethodAlias",
+                "SubSubClassWithMethodAlias",
+            ];
+            for class_name in classes {
+                Class::define(
+                    &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
                     &token,
-                    object,
-                    SimpleClass::new(env, &token, 7),
-                    5,
-                    12 + 7 + 5
-                );
+                )
+                .unwrap();
+            }
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    object,
-                    SubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    12 + (7 + 1) + 5
-                );
+            // Base class -- no aliasing.
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    object,
-                    SubSubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    12 + (7 + 2) + 5
-                );
+            let object = SimpleClass::new(&token, 12).unwrap();
 
-                let object = SubClassWithMethodAlias::new(env, &token, 12).unwrap();
+            assert_value_with_added_eq!(&token, object, SimpleClass::new(&token, 7), 5, 12 + 7 + 5);
 
-                // Subclass method works.
+            assert_value_with_added_eq!(
+                &token,
+                object,
+                SubClassWithMethodAlias::new(&token, 7),
+                5,
+                12 + (7 + 1) + 5
+            );
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    object,
-                    SubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 1) + (7 + 1) * 2 + 5
-                );
+            assert_value_with_added_eq!(
+                &token,
+                object,
+                SubSubClassWithMethodAlias::new(&token, 7),
+                5,
+                12 + (7 + 2) + 5
+            );
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    object,
-                    SubSubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 1) + (7 + 2) * 2 + 5
-                );
+            let object = SubClassWithMethodAlias::new(&token, 12).unwrap();
 
-                // Aliased method works.
+            // Subclass method works.
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    *object,
-                    SimpleClass::new(env, &token, 7),
-                    5,
-                    (12 + 1) + 7 + 5
-                );
+            assert_value_with_added_eq!(
+                &token,
+                object,
+                SubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 1) + (7 + 1) * 2 + 5
+            );
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    *object,
-                    SubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 1) + (7 + 1) + 5
-                );
+            assert_value_with_added_eq!(
+                &token,
+                object,
+                SubSubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 1) + (7 + 2) * 2 + 5
+            );
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    *object,
-                    SubSubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 1) + (7 + 2) + 5
-                );
+            // Aliased method works.
 
-                let object = SubSubClassWithMethodAlias::new(env, &token, 12).unwrap();
+            assert_value_with_added_eq!(
+                &token,
+                *object,
+                SimpleClass::new(&token, 7),
+                5,
+                (12 + 1) + 7 + 5
+            );
 
-                // Subsubclass method works.
+            assert_value_with_added_eq!(
+                &token,
+                *object,
+                SubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 1) + (7 + 1) + 5
+            );
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    object,
-                    SubSubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 2) + (7 + 2) * 3 + 5
-                );
+            assert_value_with_added_eq!(
+                &token,
+                *object,
+                SubSubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 1) + (7 + 2) + 5
+            );
 
-                // Aliased subclass method works.
+            let object = SubSubClassWithMethodAlias::new(&token, 12).unwrap();
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    *object,
-                    SubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 2) + (7 + 1) * 2 + 5
-                );
+            // Subsubclass method works.
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    *object,
-                    SubSubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 2) + (7 + 2) * 2 + 5
-                );
+            assert_value_with_added_eq!(
+                &token,
+                object,
+                SubSubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 2) + (7 + 2) * 3 + 5
+            );
 
-                // Aliased method works.
+            // Aliased subclass method works.
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    **object,
-                    SimpleClass::new(env, &token, 7),
-                    5,
-                    (12 + 2) + 7 + 5
-                );
+            assert_value_with_added_eq!(
+                &token,
+                *object,
+                SubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 2) + (7 + 1) * 2 + 5
+            );
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    **object,
-                    SubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 2) + (7 + 1) + 5
-                );
+            assert_value_with_added_eq!(
+                &token,
+                *object,
+                SubSubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 2) + (7 + 2) * 2 + 5
+            );
 
-                assert_value_with_added_eq!(
-                    env,
-                    &token,
-                    **object,
-                    SubSubClassWithMethodAlias::new(env, &token, 7),
-                    5,
-                    (12 + 2) + (7 + 2) + 5
-                );
+            // Aliased method works.
 
-                ((), token)
-            },
-        )
+            assert_value_with_added_eq!(
+                &token,
+                **object,
+                SimpleClass::new(&token, 7),
+                5,
+                (12 + 2) + 7 + 5
+            );
+
+            assert_value_with_added_eq!(
+                &token,
+                **object,
+                SubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 2) + (7 + 1) + 5
+            );
+
+            assert_value_with_added_eq!(
+                &token,
+                **object,
+                SubSubClassWithMethodAlias::new(&token, 7),
+                5,
+                (12 + 2) + (7 + 2) + 5
+            );
+
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/examples/java-lib/tests/method_call.rs
+++ b/examples/java-lib/tests/method_call.rs
@@ -10,37 +10,33 @@ mod test {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let classes = vec!["SimpleClass", "SimpleSubClass", "SimpleSubSubClass"];
-                for class_name in classes {
-                    Class::define(
-                        env,
-                        &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
-                        &token,
-                    )
-                    .unwrap();
-                }
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let classes = vec!["SimpleClass", "SimpleSubClass", "SimpleSubSubClass"];
+            for class_name in classes {
+                Class::define(
+                    &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
+                    &token,
+                )
+                .unwrap();
+            }
 
-                // Can call own methods.
+            // Can call own methods.
 
-                let object = SimpleClass::new(env, &token, 12).unwrap();
-                assert_eq!(object.value_with_added(&token, 5).unwrap(), 12 + 5);
+            let object = SimpleClass::new(&token, 12).unwrap();
+            assert_eq!(object.value_with_added(&token, 5).unwrap(), 12 + 5);
 
-                // Can call super methods.
+            // Can call super methods.
 
-                let object = SimpleSubClass::new(env, &token, 12).unwrap();
-                assert_eq!(object.value_with_added(&token, 5).unwrap(), (12 + 1) + 5);
+            let object = SimpleSubClass::new(&token, 12).unwrap();
+            assert_eq!(object.value_with_added(&token, 5).unwrap(), (12 + 1) + 5);
 
-                // Can call super-super methods.
+            // Can call super-super methods.
 
-                let object = SimpleSubSubClass::new(env, &token, 12).unwrap();
-                assert_eq!(object.value_with_added(&token, 5).unwrap(), (12 + 2) + 5);
+            let object = SimpleSubSubClass::new(&token, 12).unwrap();
+            assert_eq!(object.value_with_added(&token, 5).unwrap(), (12 + 2) + 5);
 
-                ((), token)
-            },
-        )
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/examples/java-lib/tests/method_class_argument.rs
+++ b/examples/java-lib/tests/method_class_argument.rs
@@ -13,11 +13,8 @@ mod test {
     use std::fs;
 
     macro_rules! assert_value_with_added_eq {
-        ($env:expr, $token:expr, $object:expr, $argument:expr, $value:expr, $expected:expr) => {{
-            let new_object = $object
-                .combine($token, $argument)
-                .or_npe($env, $token)
-                .unwrap();
+        ($token:expr, $object:expr, $argument:expr, $value:expr, $expected:expr) => {{
+            let new_object = $object.combine($token, $argument).or_npe($token).unwrap();
             assert_eq!(
                 new_object.value_with_added($token, $value).unwrap(),
                 $expected
@@ -26,27 +23,12 @@ mod test {
     }
 
     macro_rules! assert_value_with_added_eq_pass_by_all {
-        ($env:expr, $token:expr, $object:expr, $argument:expr, $value:expr, $expected:expr) => {
-            assert_value_with_added_eq!(
-                $env,
-                $token,
-                $object,
-                $argument.unwrap(),
-                $value,
-                $expected
-            );
+        ($token:expr, $object:expr, $argument:expr, $value:expr, $expected:expr) => {
+            assert_value_with_added_eq!($token, $object, $argument.unwrap(), $value, $expected);
+
+            assert_value_with_added_eq!($token, $object, &$argument.unwrap(), $value, $expected);
 
             assert_value_with_added_eq!(
-                $env,
-                $token,
-                $object,
-                &$argument.unwrap(),
-                $value,
-                $expected
-            );
-
-            assert_value_with_added_eq!(
-                $env,
                 $token,
                 $object,
                 Some($argument.unwrap()),
@@ -55,7 +37,6 @@ mod test {
             );
 
             assert_value_with_added_eq!(
-                $env,
                 $token,
                 $object,
                 Some(&$argument.unwrap()),
@@ -69,115 +50,102 @@ mod test {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let classes = vec!["SimpleClass", "SimpleSubClass", "SimpleSubSubClass"];
-                for class_name in classes {
-                    Class::define(
-                        env,
-                        &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
-                        &token,
-                    )
-                    .unwrap();
-                }
-
-                // Can call a method on it's own class.
-
-                let object = SimpleClass::new(env, &token, 12).unwrap();
-
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let classes = vec!["SimpleClass", "SimpleSubClass", "SimpleSubSubClass"];
+            for class_name in classes {
+                Class::define(
+                    &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
                     &token,
-                    object,
-                    SimpleClass::new(env, &token, 7),
-                    5,
-                    12 + 7 + 5
-                );
+                )
+                .unwrap();
+            }
 
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
-                    &token,
-                    object,
-                    SimpleSubClass::new(env, &token, 7),
-                    5,
-                    12 + (7 + 1) + 5
-                );
+            // Can call a method on it's own class.
 
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
-                    &token,
-                    object,
-                    SimpleSubSubClass::new(env, &token, 7),
-                    5,
-                    12 + (7 + 2) + 5
-                );
+            let object = SimpleClass::new(&token, 12).unwrap();
 
-                // Can call a method on a subclass.
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleClass::new(&token, 7),
+                5,
+                12 + 7 + 5
+            );
 
-                let object = SimpleSubClass::new(env, &token, 12).unwrap();
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleSubClass::new(&token, 7),
+                5,
+                12 + (7 + 1) + 5
+            );
 
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
-                    &token,
-                    object,
-                    SimpleClass::new(env, &token, 7),
-                    5,
-                    (12 + 1) + 7 + 5
-                );
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleSubSubClass::new(&token, 7),
+                5,
+                12 + (7 + 2) + 5
+            );
 
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
-                    &token,
-                    object,
-                    SimpleSubClass::new(env, &token, 7),
-                    5,
-                    (12 + 1) + (7 + 1) + 5
-                );
+            // Can call a method on a subclass.
 
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
-                    &token,
-                    object,
-                    SimpleSubSubClass::new(env, &token, 7),
-                    5,
-                    (12 + 1) + (7 + 2) + 5
-                );
+            let object = SimpleSubClass::new(&token, 12).unwrap();
 
-                // Can call a method on a sub-subclass.
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleClass::new(&token, 7),
+                5,
+                (12 + 1) + 7 + 5
+            );
 
-                let object = SimpleSubSubClass::new(env, &token, 12).unwrap();
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleSubClass::new(&token, 7),
+                5,
+                (12 + 1) + (7 + 1) + 5
+            );
 
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
-                    &token,
-                    object,
-                    SimpleClass::new(env, &token, 7),
-                    5,
-                    (12 + 2) + 7 + 5
-                );
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleSubSubClass::new(&token, 7),
+                5,
+                (12 + 1) + (7 + 2) + 5
+            );
 
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
-                    &token,
-                    object,
-                    SimpleSubClass::new(env, &token, 7),
-                    5,
-                    (12 + 2) + (7 + 1) + 5
-                );
+            // Can call a method on a sub-subclass.
 
-                assert_value_with_added_eq_pass_by_all!(
-                    env,
-                    &token,
-                    object,
-                    SimpleSubSubClass::new(env, &token, 7),
-                    5,
-                    (12 + 2) + (7 + 2) + 5
-                );
+            let object = SimpleSubSubClass::new(&token, 12).unwrap();
 
-                ((), token)
-            },
-        )
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleClass::new(&token, 7),
+                5,
+                (12 + 2) + 7 + 5
+            );
+
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleSubClass::new(&token, 7),
+                5,
+                (12 + 2) + (7 + 1) + 5
+            );
+
+            assert_value_with_added_eq_pass_by_all!(
+                &token,
+                object,
+                SimpleSubSubClass::new(&token, 7),
+                5,
+                (12 + 2) + (7 + 2) + 5
+            );
+
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/examples/java-lib/tests/method_override.rs
+++ b/examples/java-lib/tests/method_override.rs
@@ -11,65 +11,61 @@ mod test {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let classes = vec![
-                    "SimpleClass",
-                    "SubClassWithMethodOverride",
-                    "SubSubClassWithMethodOverride",
-                ];
-                for class_name in classes {
-                    Class::define(
-                        env,
-                        &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
-                        &token,
-                    )
-                    .unwrap();
-                }
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let classes = vec![
+                "SimpleClass",
+                "SubClassWithMethodOverride",
+                "SubSubClassWithMethodOverride",
+            ];
+            for class_name in classes {
+                Class::define(
+                    &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
+                    &token,
+                )
+                .unwrap();
+            }
 
-                // Can call own methods.
+            // Can call own methods.
 
-                let object = SimpleClass::new(env, &token, 12).unwrap();
-                assert_eq!(object.value_with_added(&token, 5).unwrap(), 12 + 5);
+            let object = SimpleClass::new(&token, 12).unwrap();
+            assert_eq!(object.value_with_added(&token, 5).unwrap(), 12 + 5);
 
-                // Can call super methods.
+            // Can call super methods.
 
-                let object = SubClassWithMethodOverride::new(env, &token, 12).unwrap();
-                assert_eq!(
-                    object.value_with_added(&token, 5).unwrap(),
-                    (12 + 1) + 5 * 2
-                );
+            let object = SubClassWithMethodOverride::new(&token, 12).unwrap();
+            assert_eq!(
+                object.value_with_added(&token, 5).unwrap(),
+                (12 + 1) + 5 * 2
+            );
 
-                let object = SubClassWithMethodOverride::new(env, &token, 12).unwrap();
-                assert_eq!(
-                    (*object).value_with_added(&token, 5).unwrap(),
-                    (12 + 1) + 5 * 2
-                );
+            let object = SubClassWithMethodOverride::new(&token, 12).unwrap();
+            assert_eq!(
+                (*object).value_with_added(&token, 5).unwrap(),
+                (12 + 1) + 5 * 2
+            );
 
-                // Can call super-super methods.
+            // Can call super-super methods.
 
-                let object = SubSubClassWithMethodOverride::new(env, &token, 12).unwrap();
-                assert_eq!(
-                    object.value_with_added(&token, 5).unwrap(),
-                    (12 + 2) + 5 * 3
-                );
+            let object = SubSubClassWithMethodOverride::new(&token, 12).unwrap();
+            assert_eq!(
+                object.value_with_added(&token, 5).unwrap(),
+                (12 + 2) + 5 * 3
+            );
 
-                let object = SubSubClassWithMethodOverride::new(env, &token, 12).unwrap();
-                assert_eq!(
-                    (*object).value_with_added(&token, 5).unwrap(),
-                    (12 + 2) + 5 * 3
-                );
+            let object = SubSubClassWithMethodOverride::new(&token, 12).unwrap();
+            assert_eq!(
+                (*object).value_with_added(&token, 5).unwrap(),
+                (12 + 2) + 5 * 3
+            );
 
-                let object = SubSubClassWithMethodOverride::new(env, &token, 12).unwrap();
-                assert_eq!(
-                    (**object).value_with_added(&token, 5).unwrap(),
-                    (12 + 2) + 5 * 3
-                );
+            let object = SubSubClassWithMethodOverride::new(&token, 12).unwrap();
+            assert_eq!(
+                (**object).value_with_added(&token, 5).unwrap(),
+                (12 + 2) + 5 * 3
+            );
 
-                ((), token)
-            },
-        )
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/examples/java-lib/tests/object_methods.rs
+++ b/examples/java-lib/tests/object_methods.rs
@@ -11,61 +11,53 @@ mod test {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let classes = vec!["ClassWithObjectMethods", "SimpleClass", "SimpleSubClass"];
-                for class_name in classes {
-                    Class::define(
-                        env,
-                        &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
-                        &token,
-                    )
-                    .unwrap();
-                }
-
-                let test_object1 = SimpleClass::new(env, &token, 12).unwrap();
-                let test_object2 = SimpleSubClass::new(env, &token, 12).unwrap();
-
-                // Call object methods.
-
-                let object = ClassWithObjectMethods::new(env, &token).unwrap();
-
-                assert!(object
-                    .test_function_object(&token, &test_object1)
-                    .or_npe(env, &token)
-                    .unwrap()
-                    .is_same_as(&token, &test_object1));
-
-                assert!(object
-                    .test_function_object(&token, &test_object2)
-                    .or_npe(env, &token)
-                    .unwrap()
-                    .is_same_as(&token, &test_object2));
-
-                // Call static methods.
-
-                assert!(ClassWithObjectMethods::test_static_function_object(
-                    env,
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let classes = vec!["ClassWithObjectMethods", "SimpleClass", "SimpleSubClass"];
+            for class_name in classes {
+                Class::define(
+                    &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
                     &token,
-                    &test_object1
                 )
-                .or_npe(env, &token)
+                .unwrap();
+            }
+
+            let test_object1 = SimpleClass::new(&token, 12).unwrap();
+            let test_object2 = SimpleSubClass::new(&token, 12).unwrap();
+
+            // Call object methods.
+
+            let object = ClassWithObjectMethods::new(&token).unwrap();
+
+            assert!(object
+                .test_function_object(&token, &test_object1)
+                .or_npe(&token)
                 .unwrap()
                 .is_same_as(&token, &test_object1));
 
-                assert!(ClassWithObjectMethods::test_static_function_object(
-                    env,
-                    &token,
-                    &test_object2
-                )
-                .or_npe(env, &token)
+            assert!(object
+                .test_function_object(&token, &test_object2)
+                .or_npe(&token)
                 .unwrap()
                 .is_same_as(&token, &test_object2));
 
-                ((), token)
-            },
-        )
+            // Call static methods.
+
+            assert!(
+                ClassWithObjectMethods::test_static_function_object(&token, &test_object1)
+                    .or_npe(&token)
+                    .unwrap()
+                    .is_same_as(&token, &test_object1)
+            );
+
+            assert!(
+                ClassWithObjectMethods::test_static_function_object(&token, &test_object2)
+                    .or_npe(&token)
+                    .unwrap()
+                    .is_same_as(&token, &test_object2)
+            );
+
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/examples/java-lib/tests/object_native_methods.rs
+++ b/examples/java-lib/tests/object_native_methods.rs
@@ -11,65 +11,59 @@ mod test {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let classes = vec![
-                    "ClassWithObjectNativeMethods",
-                    "SimpleClass",
-                    "SimpleSubClass",
-                ];
-                for class_name in classes {
-                    Class::define(
-                        env,
-                        &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
-                        &token,
-                    )
-                    .unwrap();
-                }
-
-                let test_object1 = SimpleClass::new(env, &token, 12).unwrap();
-                let test_object2 = SimpleSubClass::new(env, &token, 12).unwrap();
-
-                // Call object methods.
-
-                let object = ClassWithObjectNativeMethods::new(env, &token).unwrap();
-
-                assert!(object
-                    .test_function_object(&token, &test_object1)
-                    .or_npe(env, &token)
-                    .unwrap()
-                    .is_same_as(&token, &test_object1));
-
-                assert!(object
-                    .test_function_object(&token, &test_object2)
-                    .or_npe(env, &token)
-                    .unwrap()
-                    .is_same_as(&token, &test_object2));
-
-                // Call static methods.
-
-                assert!(ClassWithObjectNativeMethods::test_static_function_object(
-                    env,
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let classes = vec![
+                "ClassWithObjectNativeMethods",
+                "SimpleClass",
+                "SimpleSubClass",
+            ];
+            for class_name in classes {
+                Class::define(
+                    &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
                     &token,
-                    &test_object1
                 )
-                .or_npe(env, &token)
+                .unwrap();
+            }
+
+            let test_object1 = SimpleClass::new(&token, 12).unwrap();
+            let test_object2 = SimpleSubClass::new(&token, 12).unwrap();
+
+            // Call object methods.
+
+            let object = ClassWithObjectNativeMethods::new(&token).unwrap();
+
+            assert!(object
+                .test_function_object(&token, &test_object1)
+                .or_npe(&token)
                 .unwrap()
                 .is_same_as(&token, &test_object1));
 
-                assert!(ClassWithObjectNativeMethods::test_static_function_object(
-                    env,
-                    &token,
-                    &test_object2
-                )
-                .or_npe(env, &token)
+            assert!(object
+                .test_function_object(&token, &test_object2)
+                .or_npe(&token)
                 .unwrap()
                 .is_same_as(&token, &test_object2));
 
-                ((), token)
-            },
-        )
+            // Call static methods.
+
+            assert!(ClassWithObjectNativeMethods::test_static_function_object(
+                &token,
+                &test_object1
+            )
+            .or_npe(&token)
+            .unwrap()
+            .is_same_as(&token, &test_object1));
+
+            assert!(ClassWithObjectNativeMethods::test_static_function_object(
+                &token,
+                &test_object2
+            )
+            .or_npe(&token)
+            .unwrap()
+            .is_same_as(&token, &test_object2));
+
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/examples/java-lib/tests/primitive_methods.rs
+++ b/examples/java-lib/tests/primitive_methods.rs
@@ -10,78 +10,72 @@ mod test {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let classes = vec!["ClassWithPrimitiveMethods"];
-                for class_name in classes {
-                    Class::define(
-                        env,
-                        &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
-                        &token,
-                    )
-                    .unwrap();
-                }
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let classes = vec!["ClassWithPrimitiveMethods"];
+            for class_name in classes {
+                Class::define(
+                    &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
+                    &token,
+                )
+                .unwrap();
+            }
 
-                // Call object methods.
+            // Call object methods.
 
-                let object = ClassWithPrimitiveMethods::new(env, &token).unwrap();
+            let object = ClassWithPrimitiveMethods::new(&token).unwrap();
 
-                object.test_function_void(&token).unwrap();
-                assert_eq!(object.test_function_bool(&token, true).unwrap(), false);
-                assert_eq!(object.test_function_char(&token, '0').unwrap(), '1');
-                assert_eq!(object.test_function_u8(&token, 10).unwrap(), 12);
-                assert_eq!(object.test_function_i16(&token, 10).unwrap(), 13);
-                assert_eq!(object.test_function_i32(&token, 10).unwrap(), 14);
-                assert_eq!(object.test_function_i64(&token, 10).unwrap(), 15);
-                assert_eq!(object.test_function_f32(&token, 10.).unwrap(), 16.);
-                assert_eq!(object.test_function_f64(&token, 10.).unwrap(), 17.);
+            object.test_function_void(&token).unwrap();
+            assert_eq!(object.test_function_bool(&token, true).unwrap(), false);
+            assert_eq!(object.test_function_char(&token, '0').unwrap(), '1');
+            assert_eq!(object.test_function_u8(&token, 10).unwrap(), 12);
+            assert_eq!(object.test_function_i16(&token, 10).unwrap(), 13);
+            assert_eq!(object.test_function_i32(&token, 10).unwrap(), 14);
+            assert_eq!(object.test_function_i64(&token, 10).unwrap(), 15);
+            assert_eq!(object.test_function_f32(&token, 10.).unwrap(), 16.);
+            assert_eq!(object.test_function_f64(&token, 10.).unwrap(), 17.);
 
-                // Call static methods.
+            // Call static methods.
 
-                ClassWithPrimitiveMethods::test_static_function_void(env, &token).unwrap();
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_bool(env, &token, true)
-                        .unwrap(),
-                    false
-                );
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_bool(env, &token, true)
-                        .unwrap(),
-                    false
-                );
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_char(env, &token, '0').unwrap(),
-                    '1'
-                );
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_u8(env, &token, 10).unwrap(),
-                    12
-                );
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_i16(env, &token, 10).unwrap(),
-                    13
-                );
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_i32(env, &token, 10).unwrap(),
-                    14
-                );
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_i64(env, &token, 10).unwrap(),
-                    15
-                );
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_f32(env, &token, 10.).unwrap(),
-                    16.
-                );
-                assert_eq!(
-                    ClassWithPrimitiveMethods::test_static_function_f64(env, &token, 10.).unwrap(),
-                    17.
-                );
+            ClassWithPrimitiveMethods::test_static_function_void(&token).unwrap();
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_bool(&token, true).unwrap(),
+                false
+            );
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_bool(&token, true).unwrap(),
+                false
+            );
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_char(&token, '0').unwrap(),
+                '1'
+            );
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_u8(&token, 10).unwrap(),
+                12
+            );
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_i16(&token, 10).unwrap(),
+                13
+            );
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_i32(&token, 10).unwrap(),
+                14
+            );
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_i64(&token, 10).unwrap(),
+                15
+            );
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_f32(&token, 10.).unwrap(),
+                16.
+            );
+            assert_eq!(
+                ClassWithPrimitiveMethods::test_static_function_f64(&token, 10.).unwrap(),
+                17.
+            );
 
-                ((), token)
-            },
-        )
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/examples/java-lib/tests/primitive_native_methods.rs
+++ b/examples/java-lib/tests/primitive_native_methods.rs
@@ -10,80 +10,68 @@ mod test {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let classes = vec!["ClassWithPrimitiveNativeMethods"];
-                for class_name in classes {
-                    Class::define(
-                        env,
-                        &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
-                        &token,
-                    )
-                    .unwrap();
-                }
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let classes = vec!["ClassWithPrimitiveNativeMethods"];
+            for class_name in classes {
+                Class::define(
+                    &fs::read(format!("./java/rustjni/test/{}.class", class_name)).unwrap(),
+                    &token,
+                )
+                .unwrap();
+            }
 
-                // Call object methods.
+            // Call object methods.
 
-                let object = ClassWithPrimitiveNativeMethods::new(env, &token).unwrap();
+            let object = ClassWithPrimitiveNativeMethods::new(&token).unwrap();
 
-                object.test_function_void(&token).unwrap();
-                assert_eq!(object.test_function_bool(&token, true).unwrap(), false);
-                assert_eq!(object.test_function_char(&token, '0').unwrap(), '1');
-                assert_eq!(object.test_function_u8(&token, 10).unwrap(), 12);
-                assert_eq!(object.test_function_i16(&token, 10).unwrap(), 13);
-                assert_eq!(object.test_function_i32(&token, 10).unwrap(), 14);
-                assert_eq!(object.test_function_i64(&token, 10).unwrap(), 15);
-                assert_eq!(object.test_function_f32(&token, 10.).unwrap(), 16.);
-                assert_eq!(object.test_function_f64(&token, 10.).unwrap(), 17.);
+            object.test_function_void(&token).unwrap();
+            assert_eq!(object.test_function_bool(&token, true).unwrap(), false);
+            assert_eq!(object.test_function_char(&token, '0').unwrap(), '1');
+            assert_eq!(object.test_function_u8(&token, 10).unwrap(), 12);
+            assert_eq!(object.test_function_i16(&token, 10).unwrap(), 13);
+            assert_eq!(object.test_function_i32(&token, 10).unwrap(), 14);
+            assert_eq!(object.test_function_i64(&token, 10).unwrap(), 15);
+            assert_eq!(object.test_function_f32(&token, 10.).unwrap(), 16.);
+            assert_eq!(object.test_function_f64(&token, 10.).unwrap(), 17.);
 
-                // Call static methods.
+            // Call static methods.
 
-                ClassWithPrimitiveNativeMethods::test_static_function_void(env, &token).unwrap();
-                assert_eq!(
-                    ClassWithPrimitiveNativeMethods::test_static_function_bool(env, &token, true)
-                        .unwrap(),
-                    false
-                );
-                assert_eq!(
-                    ClassWithPrimitiveNativeMethods::test_static_function_char(env, &token, '0')
-                        .unwrap(),
-                    '1'
-                );
-                assert_eq!(
-                    ClassWithPrimitiveNativeMethods::test_static_function_u8(env, &token, 10)
-                        .unwrap(),
-                    12
-                );
-                assert_eq!(
-                    ClassWithPrimitiveNativeMethods::test_static_function_i16(env, &token, 10)
-                        .unwrap(),
-                    13
-                );
-                assert_eq!(
-                    ClassWithPrimitiveNativeMethods::test_static_function_i32(env, &token, 10)
-                        .unwrap(),
-                    14
-                );
-                assert_eq!(
-                    ClassWithPrimitiveNativeMethods::test_static_function_i64(env, &token, 10)
-                        .unwrap(),
-                    15
-                );
-                assert_eq!(
-                    ClassWithPrimitiveNativeMethods::test_static_function_f32(env, &token, 10.)
-                        .unwrap(),
-                    16.
-                );
-                assert_eq!(
-                    ClassWithPrimitiveNativeMethods::test_static_function_f64(env, &token, 10.)
-                        .unwrap(),
-                    17.
-                );
+            ClassWithPrimitiveNativeMethods::test_static_function_void(&token).unwrap();
+            assert_eq!(
+                ClassWithPrimitiveNativeMethods::test_static_function_bool(&token, true).unwrap(),
+                false
+            );
+            assert_eq!(
+                ClassWithPrimitiveNativeMethods::test_static_function_char(&token, '0').unwrap(),
+                '1'
+            );
+            assert_eq!(
+                ClassWithPrimitiveNativeMethods::test_static_function_u8(&token, 10).unwrap(),
+                12
+            );
+            assert_eq!(
+                ClassWithPrimitiveNativeMethods::test_static_function_i16(&token, 10).unwrap(),
+                13
+            );
+            assert_eq!(
+                ClassWithPrimitiveNativeMethods::test_static_function_i32(&token, 10).unwrap(),
+                14
+            );
+            assert_eq!(
+                ClassWithPrimitiveNativeMethods::test_static_function_i64(&token, 10).unwrap(),
+                15
+            );
+            assert_eq!(
+                ClassWithPrimitiveNativeMethods::test_static_function_f32(&token, 10.).unwrap(),
+                16.
+            );
+            assert_eq!(
+                ClassWithPrimitiveNativeMethods::test_static_function_f64(&token, 10.).unwrap(),
+                17.
+            );
 
-                ((), token)
-            },
-        )
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/rust-jni/src/call_jni_method.rs
+++ b/rust-jni/src/call_jni_method.rs
@@ -33,11 +33,11 @@ macro_rules! call_jni_object_method {
 // It's actually used.
 #[allow(unused_macros)]
 macro_rules! call_nullable_jni_method {
-    ($env:expr, $token:expr, $method:ident, $($argument:expr),*) => {
-        $token.with_owned($env, #[inline(always)] |token| {
-            let result = call_jni_method!($env, $method, $($argument),*);
+    ($token:expr, $method:ident, $($argument:expr),*) => {
+        $token.with_owned(#[inline(always)] |token| {
+            let result = call_jni_method!($token.env(), $method, $($argument),*);
             match NonNull::new(result) {
-                None => CallOutcome::Err(token.exchange($env)),
+                None => CallOutcome::Err(token.exchange()),
                 Some(result) => CallOutcome::Ok((result, token)),
             }
         })

--- a/rust-jni/src/class.rs
+++ b/rust-jni/src/class.rs
@@ -27,34 +27,25 @@ impl<'env> Class<'env> {
     /// type name.
     ///
     /// [JNI documentation](https://docs.oracle.com/javase/10/docs/specs/jni/functions.html#findclass)
-    pub fn find<'a>(
-        env: &'a JniEnv<'a>,
-        token: &NoException<'a>,
-        class_name: &str,
-    ) -> JavaResult<'a, Class<'a>> {
+    pub fn find<'a>(token: &NoException<'a>, class_name: &str) -> JavaResult<'a, Class<'a>> {
         let class_name = to_java_string(class_name);
         // Safe because the arguments are correct and because `FindClass` throws an exception
         // before returning `null`.
         let raw_class = unsafe {
-            call_nullable_jni_method!(env, token, FindClass, class_name.as_ptr() as *const c_char)
+            call_nullable_jni_method!(token, FindClass, class_name.as_ptr() as *const c_char)
         }?;
         // Safe because the argument is a valid class reference.
-        Ok(unsafe { Self::from_raw(env, raw_class) })
+        Ok(unsafe { Self::from_raw(token.env(), raw_class) })
     }
 
     /// Define a new Java class from a `.class` file contents.
     ///
     /// [JNI documentation](https://docs.oracle.com/javase/10/docs/specs/jni/functions.html#defineclass)
-    pub fn define<'a>(
-        env: &'a JniEnv<'a>,
-        bytes: &[u8],
-        token: &NoException<'a>,
-    ) -> JavaResult<'a, Class<'a>> {
+    pub fn define<'a>(bytes: &[u8], token: &NoException<'a>) -> JavaResult<'a, Class<'a>> {
         // Safe because the arguments are correct and because `DefineClass` throws an exception
         // before returning `null`.
         let raw_class = unsafe {
             call_nullable_jni_method!(
-                env,
                 token,
                 DefineClass,
                 ptr::null() as *const c_char,
@@ -64,7 +55,7 @@ impl<'env> Class<'env> {
             )?
         };
         // Safe because the argument is a valid class reference.
-        Ok(unsafe { Self::from_raw(env, raw_class) })
+        Ok(unsafe { Self::from_raw(token.env(), raw_class) })
     }
 
     /// Get the parent class of this class. Will return

--- a/rust-jni/src/classes/null_pointer_exception.rs
+++ b/rust-jni/src/classes/null_pointer_exception.rs
@@ -1,5 +1,4 @@
 use crate::classes::exception::Exception;
-use crate::env::JniEnv;
 use crate::java_methods::call_constructor;
 use crate::java_methods::FromObject;
 use crate::java_methods::JniSignature;
@@ -19,12 +18,9 @@ impl<'this> NullPointerException<'this> {
     /// Create a new [`NullPointerException`](struct.NullPointerException.html) with a message.
     ///
     /// [`NullPointerException()` javadoc](https://docs.oracle.com/javase/10/docs/api/java/lang/NullPointerException.html#<init>())
-    pub fn new(
-        env: &'this JniEnv<'this>,
-        token: &NoException<'this>,
-    ) -> JavaResult<'this, NullPointerException<'this>> {
+    pub fn new(token: &NoException<'this>) -> JavaResult<'this, NullPointerException<'this>> {
         // Safe because we ensure correct arguments and return type.
-        unsafe { call_constructor::<Self, _, fn()>(&env, token, ()) }
+        unsafe { call_constructor::<Self, _, fn()>(token, ()) }
     }
 }
 

--- a/rust-jni/src/env.rs
+++ b/rust-jni/src/env.rs
@@ -30,8 +30,8 @@ include!("call_jni_method.rs");
 /// let vm = JavaVM::create(&init_arguments).unwrap();
 /// let _ = vm.with_attached(
 ///     &AttachArguments::new(init_arguments.version()),
-///     |env: &JniEnv, token: NoException| {
-///         unsafe { env.raw_env() };
+///     |token: NoException| {
+///         unsafe { token.env().raw_env() };
 ///         ((), token)
 ///     },
 /// );

--- a/rust-jni/src/java_primitives.rs
+++ b/rust-jni/src/java_primitives.rs
@@ -64,7 +64,6 @@ macro_rules! java_method_result_trait {
 
             #[inline(always)]
             unsafe fn call_static_method<T, A>(
-                env: &'a JniEnv<'a>,
                 token: &NoException<'a>,
                 name: &str,
                 signature: &str,
@@ -74,7 +73,7 @@ macro_rules! java_method_result_trait {
                 T: JavaClassRef<'a>,
                 A: JavaArgumentTuple,
             {
-                let class = find_class::<T>(env, token)?;
+                let class = find_class::<T>(token)?;
                 let result = jni_methods::call_static_primitive_method(
                     &class,
                     token,

--- a/rust-jni/src/native_method.rs
+++ b/rust-jni/src/native_method.rs
@@ -161,8 +161,8 @@ java_argument_type_impls! {
 /// #     let vm = JavaVM::create(&init_arguments).unwrap();
 /// #     let _ = vm.with_attached(
 /// #        &AttachArguments::new(init_arguments.version()),
-/// #        |env: &JniEnv, token: NoException| {
-/// #            ((), jni_main(env, token).unwrap())
+/// #        |token: NoException| {
+/// #            ((), jni_main(token).unwrap())
 /// #        },
 /// #     );
 /// # }
@@ -181,17 +181,16 @@ java_argument_type_impls! {
 ///         raw_class,
 ///         (raw_argument,),
 ///         |class, token, (argument,)| {
-///             let env = class.env();
 ///             assert_eq!(
 ///                 class
 ///                     .get_name(&token)
-///                     .or_npe(env, &token)
+///                     .or_npe(&token)
 ///                     .unwrap()
 ///                     .as_string(&token),
 ///                 "java.lang.String",
 ///             );
-///             let result = String::value_of_int(env, &token, *argument)
-///                 .or_npe(env, &token)
+///             let result = String::value_of_int(&token, *argument)
+///                 .or_npe(&token)
 ///                 .unwrap();
 ///             assert_eq!(result.as_string(&token), "17");
 ///             (Ok(Box::new(result)), token)
@@ -199,11 +198,11 @@ java_argument_type_impls! {
 ///     )
 /// }
 ///
-/// # fn jni_main<'a>(env: &'a JniEnv<'a>, token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
+/// # fn jni_main<'a>(token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
 /// # unsafe {
-/// let string_class = String::empty(env, &token)?.class(&token);
+/// let string_class = String::empty(&token)?.class(&token);
 /// let string = Java_java_lang_String_valueOf__I(
-///     env.raw_env().as_ptr(),
+///     token.env().raw_env().as_ptr(),
 ///     string_class.raw_object().as_ptr(),
 ///     17 as jni_sys::jint,
 /// );
@@ -226,8 +225,8 @@ java_argument_type_impls! {
 /// #     let vm = JavaVM::create(&init_arguments).unwrap();
 /// #     let _ = vm.with_attached(
 /// #        &AttachArguments::new(init_arguments.version()),
-/// #        |env: &JniEnv, token: NoException| {
-/// #            ((), jni_main(env, token).unwrap())
+/// #        |token: NoException| {
+/// #            ((), jni_main(token).unwrap())
 /// #        },
 /// #     );
 /// # }
@@ -246,16 +245,15 @@ java_argument_type_impls! {
 ///         raw_class,
 ///         (raw_argument,),
 ///         |class, token, (argument,)| {
-///             let env = class.env();
 ///             assert_eq!(
 ///                 class
 ///                     .get_name(&token)
-///                     .or_npe(env, &token)
+///                     .or_npe(&token)
 ///                     .unwrap()
 ///                     .as_string(&token),
 ///                 "java.lang.String",
 ///             );
-///             let result = String::value_of_int(env, &token, *argument)
+///             let result = String::value_of_int(&token, *argument)
 ///                 .unwrap();
 ///             if result.as_ref().unwrap().as_string(&token) == "17" {
 ///                 (Ok(Box::new(result)), token)
@@ -266,11 +264,11 @@ java_argument_type_impls! {
 ///     )
 /// }
 ///
-/// # fn jni_main<'a>(env: &'a JniEnv<'a>, token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
+/// # fn jni_main<'a>(token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
 /// # unsafe {
-/// let string_class = String::empty(env, &token)?.class(&token);
+/// let string_class = String::empty(&token)?.class(&token);
 /// let string = Java_java_lang_String_valueOf__I(
-///     env.raw_env().as_ptr(),
+///     token.env().raw_env().as_ptr(),
 ///     string_class.raw_object().as_ptr(),
 ///     17 as jni_sys::jint,
 /// );
@@ -292,8 +290,8 @@ java_argument_type_impls! {
 /// #     let vm = JavaVM::create(&init_arguments).unwrap();
 /// #     let _ = vm.with_attached(
 /// #        &AttachArguments::new(init_arguments.version()),
-/// #        |env: &JniEnv, token: NoException| {
-/// #            ((), jni_main(env, token).unwrap())
+/// #        |token: NoException| {
+/// #            ((), jni_main(token).unwrap())
 /// #        },
 /// #     );
 /// # }
@@ -312,7 +310,7 @@ java_argument_type_impls! {
 ///         raw_class,
 ///         (raw_argument,),
 ///         |class, token, (argument,)| {
-///             let exception = Throwable::new(class.env(), &token).unwrap();
+///             let exception = Throwable::new(&token).unwrap();
 ///             let token = exception.throw(token);
 ///             let (exception, token) = token.unwrap();
 ///             (Err(exception), token)
@@ -320,17 +318,17 @@ java_argument_type_impls! {
 ///     )
 /// }
 ///
-/// # fn jni_main<'a>(env: &'a JniEnv<'a>, token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
+/// # fn jni_main<'a>(token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
 /// # unsafe {
-/// let string_class = String::empty(env, &token)?.class(&token);
+/// let string_class = String::empty(&token)?.class(&token);
 /// let string = Java_java_lang_String_valueOf__I(
-///     env.raw_env().as_ptr(),
+///     token.env().raw_env().as_ptr(),
 ///     string_class.raw_object().as_ptr(),
 ///     17 as jni_sys::jint,
 /// );
 /// assert_eq!(string, ptr::null_mut());
 ///
-/// let raw_env = env.raw_env().as_ptr();
+/// let raw_env = token.env().raw_env().as_ptr();
 /// let jni_fn = ((**raw_env).ExceptionOccurred).unwrap();
 /// let throwable = jni_fn(raw_env);
 /// assert_ne!(throwable, ptr::null_mut());
@@ -365,10 +363,10 @@ where
     generic_native_method_implementation::<R::JniType, A::JniType, _>(
         raw_env,
         raw_arguments,
-        |env, token, arguments| {
+        |token, arguments| {
             // Should not panic if the class pointer is valid.
-            let class = Class::from_raw(env, NonNull::new(raw_class).unwrap());
-            let arguments = <A as ToJavaNativeArgumentTuple>::from_raw(env, arguments);
+            let class = Class::from_raw(token.env(), NonNull::new(raw_class).unwrap());
+            let arguments = <A as ToJavaNativeArgumentTuple>::from_raw(token.env(), arguments);
             let (result, token) = callback(&class, token, &arguments);
             let java_result = to_jni_type::<R>(result, token);
             // We don't own the reference.
@@ -403,8 +401,8 @@ where
 /// #     let vm = JavaVM::create(&init_arguments).unwrap();
 /// #     let _ = vm.with_attached(
 /// #        &AttachArguments::new(init_arguments.version()),
-/// #        |env: &JniEnv, token: NoException| {
-/// #            ((), jni_main(env, token).unwrap())
+/// #        |token: NoException| {
+/// #            ((), jni_main(token).unwrap())
 /// #        },
 /// #     );
 /// # }
@@ -423,10 +421,9 @@ where
 ///         raw_object,
 ///         (raw_argument,),
 ///         |object, token, (argument,)| {
-///             let env = object.env();
 ///             let argument = argument
 ///                 .as_ref()
-///                 .or_npe(env, &token)
+///                 .or_npe(&token)
 ///                 .unwrap();
 ///             let result = object.equals(&token, &argument).unwrap();
 ///             (Ok(Box::new(result)), token)
@@ -434,12 +431,12 @@ where
 ///     )
 /// }
 ///
-/// # fn jni_main<'a>(env: &'a JniEnv<'a>, token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
+/// # fn jni_main<'a>(token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
 /// # unsafe {
-/// let string1 = String::empty(env, &token)?;
-/// let string2 = String::new(env, &token, "")?;
+/// let string1 = String::empty(&token)?;
+/// let string2 = String::new(&token, "")?;
 /// let equals = Java_java_lang_Object_equals__Ljava_lang_Object_2(
-///     env.raw_env().as_ptr(),
+///     token.env().raw_env().as_ptr(),
 ///     string1.raw_object().as_ptr(),
 ///     string2.raw_object().as_ptr(),
 /// );
@@ -462,8 +459,8 @@ where
 /// #     let vm = JavaVM::create(&init_arguments).unwrap();
 /// #     let _ = vm.with_attached(
 /// #        &AttachArguments::new(init_arguments.version()),
-/// #        |env: &JniEnv, token: NoException| {
-/// #            ((), jni_main(env, token).unwrap())
+/// #        |token: NoException| {
+/// #            ((), jni_main(token).unwrap())
 /// #        },
 /// #     );
 /// # }
@@ -482,7 +479,7 @@ where
 ///         raw_object,
 ///         (raw_argument,),
 ///         |object, token, (argument,)| {
-///             let exception = Throwable::new(object.env(), &token).unwrap();
+///             let exception = Throwable::new(&token).unwrap();
 ///             let token = exception.throw(token);
 ///             let (exception, token) = token.unwrap();
 ///             (Err(exception), token)
@@ -490,18 +487,18 @@ where
 ///     )
 /// }
 ///
-/// # fn jni_main<'a>(env: &'a JniEnv<'a>, token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
+/// # fn jni_main<'a>(token: NoException<'a>) -> JavaResult<'a, NoException<'a>> {
 /// # unsafe {
-/// let string1 = String::empty(env, &token)?;
-/// let string2 = String::new(env, &token, "")?;
+/// let string1 = String::empty(&token)?;
+/// let string2 = String::new(&token, "")?;
 /// let equals = Java_java_lang_Object_equals__Ljava_lang_Object_2(
-///     env.raw_env().as_ptr(),
+///     token.env().raw_env().as_ptr(),
 ///     string1.raw_object().as_ptr(),
 ///     string2.raw_object().as_ptr(),
 /// );
 /// assert_eq!(equals, jni_sys::JNI_FALSE);
 ///
-/// let raw_env = env.raw_env().as_ptr();
+/// let raw_env = token.env().raw_env().as_ptr();
 /// let jni_fn = ((**raw_env).ExceptionOccurred).unwrap();
 /// let throwable = jni_fn(raw_env);
 /// assert_ne!(throwable, ptr::null_mut());
@@ -536,10 +533,10 @@ where
     generic_native_method_implementation::<R::JniType, A::JniType, _>(
         raw_env,
         raw_arguments,
-        |env, token, arguments| {
+        |token, arguments| {
             // Should not panic if the object pointer is valid.
-            let object = Object::from_raw(env, NonNull::new(raw_object).unwrap());
-            let arguments = <A as ToJavaNativeArgumentTuple>::from_raw(env, arguments);
+            let object = Object::from_raw(token.env(), NonNull::new(raw_object).unwrap());
+            let arguments = <A as ToJavaNativeArgumentTuple>::from_raw(token.env(), arguments);
             let (result, token) = callback(&object, token, &arguments);
             let java_result = to_jni_type::<R>(result, token);
             // We don't own the reference.
@@ -596,7 +593,7 @@ unsafe fn generic_native_method_implementation<R, A, F>(
     callback: F,
 ) -> R
 where
-    for<'a> F: FnOnce(&'a JniEnv<'a>, NoException<'a>, A) -> R + panic::UnwindSafe,
+    for<'a> F: FnOnce(NoException<'a>, A) -> R + panic::UnwindSafe,
     R: JniType,
     A: JniArgumentTypeTuple + panic::UnwindSafe,
 {
@@ -624,7 +621,7 @@ where
         #[allow(unused_unsafe)]
         let env = unsafe { JniEnv::native(&vm, NonNull::new(raw_env).unwrap()) };
         let token = env.token();
-        let result = callback(&env, token, arguments);
+        let result = callback(token, arguments);
         // We don't own the reference.
         mem::forget(env);
         result

--- a/rust-jni/src/object.rs
+++ b/rust-jni/src/object.rs
@@ -127,9 +127,8 @@ impl<'env> Object<'env> {
     pub(crate) fn clone_object(&self, token: &NoException<'env>) -> JavaResult<'env, Object<'env>> {
         // Safe because arguments are ensured to be the correct by construction and because
         // `NewLocalRef` throws an exception before returning `null`.
-        let raw_object = unsafe {
-            call_nullable_jni_method!(self.env(), token, NewLocalRef, self.raw_object().as_ptr())?
-        };
+        let raw_object =
+            unsafe { call_nullable_jni_method!(token, NewLocalRef, self.raw_object().as_ptr())? };
         // Safe because the argument is a valid class reference.
         Ok(unsafe { Self::from_raw(self.env, raw_object) })
     }
@@ -172,12 +171,9 @@ impl<'env> Object<'env> {
     /// Create a new [`Object`](struct.Object.html) with a message.
     ///
     /// [`Object()` javadoc](https://docs.oracle.com/javase/10/docs/api/java/lang/Object.html#<init>())
-    pub fn new(
-        env: &'env JniEnv<'env>,
-        token: &NoException<'env>,
-    ) -> JavaResult<'env, Object<'env>> {
+    pub fn new(token: &NoException<'env>) -> JavaResult<'env, Object<'env>> {
         // Safe because we ensure correct arguments and return type.
-        unsafe { call_constructor::<Self, _, fn()>(&env, token, ()) }
+        unsafe { call_constructor::<Self, _, fn()>(token, ()) }
     }
 
     /// Construct from a raw pointer. Unsafe because an invalid pointer may be passed

--- a/rust-jni/src/result.rs
+++ b/rust-jni/src/result.rs
@@ -1,4 +1,3 @@
-use crate::env::JniEnv;
 use crate::java_class::JavaClassRef;
 use crate::java_class::NullableJavaClassExt;
 use crate::throwable::Throwable;
@@ -17,8 +16,8 @@ where
     R: JavaClassRef<'a>,
 {
     #[inline(always)]
-    fn or_npe(self, env: &'a JniEnv<'a>, token: &NoException<'a>) -> JavaResult<'a, R> {
+    fn or_npe(self, token: &NoException<'a>) -> JavaResult<'a, R> {
         let result = self?;
-        result.or_npe(env, token)
+        result.or_npe(token)
     }
 }

--- a/rust-jni/src/throwable.rs
+++ b/rust-jni/src/throwable.rs
@@ -39,7 +39,7 @@ impl<'env> Throwable<'env> {
             );
         }
         // Safe becuase we just threw the exception.
-        unsafe { token.exchange(self.env()) }
+        unsafe { token.exchange() }
     }
 
     /// Returns a short description of this [`Throwable`](struct.Throwable.html).
@@ -64,27 +64,19 @@ impl<'env> Throwable<'env> {
     /// Create a new [`Throwable`](struct.Throwable.html).
     ///
     /// [`Throwable(String)` javadoc](https://docs.oracle.com/javase/10/docs/api/java/lang/Throwable.html#<init>())
-    pub fn new(
-        env: &'env JniEnv<'env>,
-        token: &NoException<'env>,
-    ) -> JavaResult<'env, Throwable<'env>> {
-        unsafe { call_constructor::<Self, _, fn()>(env, token, ()) }
+    pub fn new(token: &NoException<'env>) -> JavaResult<'env, Throwable<'env>> {
+        unsafe { call_constructor::<Self, _, fn()>(token, ()) }
     }
 
     /// Create a new [`Throwable`](struct.Throwable.html) with a message.
     ///
     /// [`Throwable(String)` javadoc](https://docs.oracle.com/javase/10/docs/api/java/lang/Throwable.html#<init>(java.lang.String))
     pub fn new_with_message(
-        env: &'env JniEnv<'env>,
         token: &NoException<'env>,
         message: impl JavaObjectArgument<'env, String<'env>>,
     ) -> JavaResult<'env, Throwable<'env>> {
         unsafe {
-            call_constructor::<Self, _, fn(Option<&String<'env>>)>(
-                env,
-                token,
-                (message.as_argument(),),
-            )
+            call_constructor::<Self, _, fn(Option<&String<'env>>)>(token, (message.as_argument(),))
         }
     }
 
@@ -92,16 +84,11 @@ impl<'env> Throwable<'env> {
     ///
     /// [`Throwable(String)` javadoc](https://docs.oracle.com/javase/10/docs/api/java/lang/Throwable.html#<init>(java.lang.Throwable))
     pub fn new_with_cause(
-        env: &'env JniEnv<'env>,
         token: &NoException<'env>,
         cause: impl JavaObjectArgument<'env, Throwable<'env>>,
     ) -> JavaResult<'env, Throwable<'env>> {
         unsafe {
-            call_constructor::<Self, _, fn(Option<&Throwable<'env>>)>(
-                env,
-                token,
-                (cause.as_argument(),),
-            )
+            call_constructor::<Self, _, fn(Option<&Throwable<'env>>)>(token, (cause.as_argument(),))
         }
     }
 
@@ -109,14 +96,12 @@ impl<'env> Throwable<'env> {
     ///
     /// [`Throwable(String)` javadoc](https://docs.oracle.com/javase/10/docs/api/java/lang/Throwable.html#<init>(java.lang.String,java.lang.Throwable))
     pub fn new_with_message_and_cause(
-        env: &'env JniEnv<'env>,
         token: &NoException<'env>,
         message: impl JavaObjectArgument<'env, String<'env>>,
         cause: impl JavaObjectArgument<'env, Throwable<'env>>,
     ) -> JavaResult<'env, Throwable<'env>> {
         unsafe {
             call_constructor::<Self, _, fn(Option<&String<'env>>, Option<&Throwable<'env>>)>(
-                env,
                 token,
                 (message.as_argument(), cause.as_argument()),
             )

--- a/rust-jni/src/token.rs
+++ b/rust-jni/src/token.rs
@@ -2,7 +2,6 @@ use crate::env::JniEnv;
 use crate::jni_bool;
 use crate::result::JavaResult;
 use crate::throwable::Throwable;
-use core::marker::PhantomData;
 use std::mem;
 use std::ptr::NonNull;
 
@@ -40,7 +39,7 @@ include!("call_jni_method.rs");
 /// let vm = JavaVM::create(&init_arguments).unwrap();
 /// let _ = vm.with_attached(
 ///     &AttachArguments::new(init_arguments.version()),
-///     |_env: &JniEnv, token: NoException| ((), token),
+///     |token: NoException| ((), token),
 /// );
 /// # }
 /// #
@@ -61,8 +60,8 @@ include!("call_jni_method.rs");
 /// let empty_string_length = vm
 ///     .with_attached(
 ///         &AttachArguments::new(init_arguments.version()),
-///         |env, token| {
-///             let string = java::lang::String::empty(env, &token).unwrap();
+///         |token| {
+///             let string = java::lang::String::empty(&token).unwrap();
 ///             (string.len(&token), token)
 ///         },
 ///     )
@@ -131,9 +130,9 @@ include!("call_jni_method.rs");
 /// let _ = vm
 ///     .with_attached(
 ///         &AttachArguments::new(init_arguments.version()),
-///         |env, token| {
-///             let string = java::lang::Class::find(env, &token, "java/lang/String").unwrap();
-///             let exception = java::lang::Class::find(env, &token, "invalid").unwrap_err();
+///         |token| {
+///             let string = java::lang::Class::find(&token, "java/lang/String").unwrap();
+///             let exception = java::lang::Class::find(&token, "invalid").unwrap_err();
 ///             ((), token)
 ///         },
 ///     );
@@ -166,11 +165,11 @@ include!("call_jni_method.rs");
 /// let _ = vm
 ///     .with_attached(
 ///         &AttachArguments::new(init_arguments.version()),
-///         |env, token| {
-///             let exception = java::lang::Class::find(env, &token, "invalid").unwrap_err();
+///         |token| {
+///             let exception = java::lang::Class::find(&token, "invalid").unwrap_err();
 ///             exception.throw(token);
 ///             // Doesn't compile! Can't use the token any more.
-///             let _ = java::lang::String::empty(env, &token);
+///             let _ = java::lang::String::empty(&token);
 ///             ((), token)
 ///         },
 ///     );
@@ -191,11 +190,11 @@ include!("call_jni_method.rs");
 /// let _ = vm
 ///     .with_attached(
 ///         &AttachArguments::new(init_arguments.version()),
-///         |env, token| {
-///             let exception = java::lang::Class::find(env, &token, "invalid").unwrap_err();
+///         |token| {
+///             let exception = java::lang::Class::find(&token, "invalid").unwrap_err();
 ///             let exception_token = exception.throw(token);
 ///             let (exception, token) = exception_token.unwrap();
-///             let _ = java::lang::String::empty(env, &token); // can call Java methods again.
+///             let _ = java::lang::String::empty(&token); // can call Java methods again.
 ///             ((), token)
 ///         },
 ///     );
@@ -215,7 +214,7 @@ include!("call_jni_method.rs");
 /// # let vm = JavaVM::create(&init_arguments).unwrap();
 /// let _ = vm.with_attached(
 ///     &AttachArguments::new(init_arguments.version()),
-///     |env, token| {
+///     |token| {
 ///         let token = thread::spawn(move || {
 ///             token // doesn't compile!
 ///         })
@@ -235,7 +234,7 @@ include!("call_jni_method.rs");
 /// # let vm = JavaVM::create(&init_arguments).unwrap();
 /// let _ = vm.with_attached(
 ///     &AttachArguments::new(init_arguments.version()),
-///     |env, token| {
+///     |token| {
 ///         thread::spawn(|| {
 ///             let _ = &token; // doesn't compile!
 ///         });
@@ -245,7 +244,7 @@ include!("call_jni_method.rs");
 /// ```
 #[derive(Debug)]
 pub struct NoException<'this> {
-    _env: PhantomData<&'this JniEnv<'this>>,
+    env: &'this JniEnv<'this>,
 }
 
 /// A token that like [`NoException`](struct.NoException.html) represents that there is no
@@ -309,10 +308,14 @@ pub(crate) enum CallOutcome<'a, T> {
 impl<'this> NoException<'this> {
     /// Unsafe because it creates a new no-exception token when there might be a pending exception.
     #[inline(always)]
-    pub(crate) unsafe fn new<'env>(_env: &JniEnv<'env>) -> NoException<'env> {
-        NoException {
-            _env: PhantomData::<&JniEnv>,
-        }
+    pub(crate) unsafe fn new<'env>(env: &'env JniEnv<'env>) -> NoException<'env> {
+        NoException { env }
+    }
+
+    /// Get the reference to the underlying [`JniEnv`](struct.JniEnv.html).
+    #[inline(always)]
+    pub fn env(&self) -> &'this JniEnv<'this> {
+        self.env
     }
 
     /// Consume the [`NoException`](struct.NoException.html) token. After the token is consumed
@@ -329,8 +332,8 @@ impl<'this> NoException<'this> {
     /// Unsafe because there might not actually be a pending exception when this method is called.
     #[cold]
     #[inline(always)]
-    pub(crate) unsafe fn exchange(self, env: &'this JniEnv<'this>) -> Exception<'this> {
-        Exception::new(env)
+    pub(crate) unsafe fn exchange(self) -> Exception<'this> {
+        Exception::new(self.env)
     }
 
     /// Execute code that can throw an exception without giving up the ownership of the
@@ -372,7 +375,6 @@ impl<'this> NoException<'this> {
     // TODO(https://github.com/rust-lang/cargo/issues/7606): make documentation visible.
     pub(crate) fn with_owned<Out, F: FnOnce(Self) -> CallOutcome<'this, Out>>(
         &self,
-        env: &'this JniEnv<'this>,
         function: F,
     ) -> JavaResult<'this, Out> {
         // Safe, because we check for a pending exception after the call
@@ -396,15 +398,15 @@ impl<'this> NoException<'this> {
             }
             CallOutcome::Unknown(result) => {
                 // Safe because the argument is ensured to be correct references by construction.
-                match NonNull::new(unsafe { call_jni_method!(env, ExceptionOccurred) }) {
+                match NonNull::new(unsafe { call_jni_method!(self.env, ExceptionOccurred) }) {
                     None => Ok(result),
                     Some(raw_java_throwable) => {
                         // Safe because the argument is ensured to be correct references by construction.
                         unsafe {
-                            call_jni_method!(env, ExceptionClear);
+                            call_jni_method!(self.env, ExceptionClear);
                         }
                         // Safe because the arguments are correct.
-                        Err(unsafe { Throwable::from_raw(env, raw_java_throwable) })
+                        Err(unsafe { Throwable::from_raw(self.env, raw_java_throwable) })
                     }
                 }
             }
@@ -440,16 +442,12 @@ impl<'this> NoException<'this> {
     /// pending exception.
     #[inline(always)]
     unsafe fn clone(&self) -> Self {
-        NoException {
-            _env: PhantomData::<&JniEnv>,
-        }
+        NoException { env: self.env }
     }
 
     #[cfg(test)]
-    pub(crate) fn test<'a>() -> NoException<'a> {
-        NoException {
-            _env: PhantomData::<&JniEnv>,
-        }
+    pub(crate) fn test<'env>(env: &'env JniEnv<'env>) -> NoException<'env> {
+        NoException { env }
     }
 }
 
@@ -468,9 +466,9 @@ mod no_exception_tests {
     fn with_owned_ok() {
         let vm = JavaVMRef::test_default();
         let env = JniEnv::test_default(&vm);
-        let token = NoException::test();
+        let token = NoException::test(&env);
         let result = token
-            .with_owned(&env, |token| CallOutcome::Ok((12, token)))
+            .with_owned(|token| CallOutcome::Ok((12, token)))
             .unwrap();
         assert_eq!(result, 12);
     }
@@ -498,11 +496,9 @@ mod no_exception_tests {
             .in_sequence(&mut sequence);
         let vm = JavaVMRef::test_default();
         let env = JniEnv::test(&vm, raw_env_ptr);
-        let token = NoException::test();
+        let token = NoException::test(&env);
         let exception = token
-            .with_owned::<(), _>(&env, |token| {
-                CallOutcome::Err(unsafe { token.exchange(&env) })
-            })
+            .with_owned::<(), _>(|token| CallOutcome::Err(unsafe { token.exchange() }))
             .unwrap_err();
         assert_eq!(unsafe { exception.raw_object().as_ptr() }, raw_throwable);
         // Prevent unmocked drop.
@@ -532,9 +528,9 @@ mod no_exception_tests {
             .in_sequence(&mut sequence);
         let vm = JavaVMRef::test_default();
         let env = JniEnv::test(&vm, raw_env_ptr);
-        let token = NoException::test();
+        let token = NoException::test(&env);
         let exception = token
-            .with_owned(&env, |_token| CallOutcome::Unknown(12))
+            .with_owned(|_token| CallOutcome::Unknown(12))
             .unwrap_err();
         assert_eq!(unsafe { exception.raw_object().as_ptr() }, raw_throwable);
         // Prevent unmocked drop.
@@ -554,10 +550,8 @@ mod no_exception_tests {
             .returning_st(|_env| ptr::null_mut());
         let vm = JavaVMRef::test_default();
         let env = JniEnv::test(&vm, raw_env_ptr);
-        let token = NoException::test();
-        let result = token
-            .with_owned(&env, |_token| CallOutcome::Unknown(12))
-            .unwrap();
+        let token = NoException::test(&env);
+        let result = token.with_owned(|_token| CallOutcome::Unknown(12)).unwrap();
         assert_eq!(result, 12);
     }
 }

--- a/rust-jni/src/token.rs
+++ b/rust-jni/src/token.rs
@@ -462,6 +462,16 @@ mod no_exception_tests {
     generate_jni_env_mock!(jni_mock);
 
     #[test]
+    fn env() {
+        let vm = JavaVMRef::test_default();
+        let env = JniEnv::test_default(&vm);
+        let token = NoException::test(&env);
+        unsafe {
+            assert_eq!(token.env().raw_env(), env.raw_env());
+        }
+    }
+
+    #[test]
     #[serial]
     fn with_owned_ok() {
         let vm = JavaVMRef::test_default();

--- a/rust-jni/tests/class.rs
+++ b/rust-jni/tests/class.rs
@@ -8,40 +8,37 @@ mod class {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let class = Class::find(env, &token, "java/lang/RuntimeException").unwrap();
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let class = Class::find(&token, "java/lang/RuntimeException").unwrap();
 
-                assert!(class
-                    .class(&token)
-                    .is_same_as(&token, &Class::class(env, &token).unwrap(),));
+            assert!(class
+                .class(&token)
+                .is_same_as(&token, &Class::class(&token).unwrap(),));
 
-                let parent_class = Throwable::class(env, &token).unwrap();
+            let parent_class = Throwable::class(&token).unwrap();
 
-                assert!(class.is_subtype_of(&token, &parent_class));
-                assert!(!parent_class.is_subtype_of(&token, &class));
+            assert!(class.is_subtype_of(&token, &parent_class));
+            assert!(!parent_class.is_subtype_of(&token, &class));
 
-                assert!(class
-                    .parent(&token)
+            assert!(class
+                .parent(&token)
+                .unwrap()
+                .parent(&token)
+                .unwrap()
+                .is_same_as(&token, &parent_class));
+
+            let exception = Class::find(&token, "java/lang/Invalid").unwrap_err();
+            assert_eq!(
+                exception
+                    .get_message(&token)
+                    .or_npe(&token)
                     .unwrap()
-                    .parent(&token)
-                    .unwrap()
-                    .is_same_as(&token, &parent_class));
+                    .as_string(&token),
+                "java/lang/Invalid"
+            );
 
-                let exception = Class::find(env, &token, "java/lang/Invalid").unwrap_err();
-                assert_eq!(
-                    exception
-                        .get_message(&token)
-                        .or_npe(env, &token)
-                        .unwrap()
-                        .as_string(&token),
-                    "java/lang/Invalid"
-                );
-
-                ((), token)
-            },
-        )
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/rust-jni/tests/no_exception_token.rs
+++ b/rust-jni/tests/no_exception_token.rs
@@ -5,19 +5,16 @@ mod create_envs {
     fn example_with_attached(vm: &JavaVM, init_arguments: &InitArguments) {
         let _ = vm.with_attached(
             &AttachArguments::new(init_arguments.version()),
-            |_env: &JniEnv, token: NoException| ((), token),
+            |token: NoException| ((), token),
         );
     }
 
     fn example_empty_string_length(vm: &JavaVM, init_arguments: &InitArguments) {
         let empty_string_length = vm
-            .with_attached(
-                &AttachArguments::new(init_arguments.version()),
-                |env, token| {
-                    let string = java::lang::String::empty(env, &token).unwrap();
-                    (string.len(&token), token)
-                },
-            )
+            .with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+                let string = java::lang::String::empty(&token).unwrap();
+                (string.len(&token), token)
+            })
             .unwrap();
         assert_eq!(empty_string_length, 0);
     }
@@ -31,29 +28,23 @@ mod create_envs {
 
     fn example_throws_exception(vm: &JavaVM, init_arguments: &InitArguments) {
         let _ = vm
-            .with_attached(
-                &AttachArguments::new(init_arguments.version()),
-                |env, token| {
-                    let _string = java::lang::Class::find(env, &token, "java/lang/String").unwrap();
-                    let _exception = java::lang::Class::find(env, &token, "invalid").unwrap_err();
-                    ((), token)
-                },
-            )
+            .with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+                let _string = java::lang::Class::find(&token, "java/lang/String").unwrap();
+                let _exception = java::lang::Class::find(&token, "invalid").unwrap_err();
+                ((), token)
+            })
             .unwrap();
     }
 
     fn example_rethrows_exception(vm: &JavaVM, init_arguments: &InitArguments) {
         let _ = vm
-            .with_attached(
-                &AttachArguments::new(init_arguments.version()),
-                |env, token| {
-                    let exception = java::lang::Class::find(env, &token, "invalid").unwrap_err();
-                    let exception_token = exception.throw(token);
-                    let (_exception, token) = exception_token.unwrap();
-                    let _ = java::lang::String::empty(env, &token); // can call Java methods again.
-                    ((), token)
-                },
-            )
+            .with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+                let exception = java::lang::Class::find(&token, "invalid").unwrap_err();
+                let exception_token = exception.throw(token);
+                let (_exception, token) = exception_token.unwrap();
+                let _ = java::lang::String::empty(&token); // can call Java methods again.
+                ((), token)
+            })
             .unwrap();
     }
 

--- a/rust-jni/tests/object.rs
+++ b/rust-jni/tests/object.rs
@@ -8,74 +8,69 @@ mod class {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let object = Object::new(env, &token).unwrap();
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let object = Object::new(&token).unwrap();
 
-                assert!(object.class(&token).is_same_as(
-                    &token,
-                    &Class::find(env, &token, "java/lang/Object").unwrap(),
-                ));
+            assert!(object
+                .class(&token)
+                .is_same_as(&token, &Class::find(&token, "java/lang/Object").unwrap(),));
 
-                assert!(object.is_same_as(&token, &object));
-                assert!(object.is_instance_of(
-                    &token,
-                    &Class::find(env, &token, "java/lang/Object").unwrap()
-                ));
+            assert!(object.is_same_as(&token, &object));
+            assert!(
+                object.is_instance_of(&token, &Class::find(&token, "java/lang/Object").unwrap())
+            );
 
-                assert!(object
-                    .clone_object(&token)
-                    .unwrap()
-                    .is_same_as(&token, &object));
-                assert!(object
-                    .clone_object(&token)
-                    .unwrap()
-                    .equals(&token, &object)
-                    .unwrap());
+            assert!(object
+                .clone_object(&token)
+                .unwrap()
+                .is_same_as(&token, &object));
+            assert!(object
+                .clone_object(&token)
+                .unwrap()
+                .equals(&token, &object)
+                .unwrap());
 
-                assert_eq!(object.clone(), object);
+            assert_eq!(object.clone(), object);
 
-                let string1 = String::new(env, &token, "test").unwrap();
-                let string2 = string1.clone_object(&token).unwrap();
-                let string3 = String::new(env, &token, "test").unwrap();
+            let string1 = String::new(&token, "test").unwrap();
+            let string2 = string1.clone_object(&token).unwrap();
+            let string3 = String::new(&token, "test").unwrap();
 
-                assert!(string1.is_same_as(&token, &string1));
-                assert!(string1.is_same_as(&token, &string2));
-                assert!(!string1.is_same_as(&token, &string3));
+            assert!(string1.is_same_as(&token, &string1));
+            assert!(string1.is_same_as(&token, &string2));
+            assert!(!string1.is_same_as(&token, &string3));
 
-                assert_eq!(string1, string1);
-                assert_eq!(string1, string2);
-                assert_ne!(string1, string3);
+            assert_eq!(string1, string1);
+            assert_eq!(string1, string2);
+            assert_ne!(string1, string3);
 
-                assert!(string1.equals(&token, &string1).unwrap());
-                assert!(string1.equals(&token, Some(&string2)).unwrap());
-                assert!(string1.equals(&token, Some(string2)).unwrap());
-                assert!(string1.equals(&token, string3).unwrap());
+            assert!(string1.equals(&token, &string1).unwrap());
+            assert!(string1.equals(&token, Some(&string2)).unwrap());
+            assert!(string1.equals(&token, Some(string2)).unwrap());
+            assert!(string1.equals(&token, string3).unwrap());
 
-                assert!(string1
-                    .equals(&token, &String::new(env, &token, "test").unwrap())
-                    .unwrap());
-                assert!(string1
-                    .equals(&token, Some(&String::new(env, &token, "test").unwrap()))
-                    .unwrap());
-                assert!(string1
-                    .equals(&token, Some(String::new(env, &token, "test").unwrap()))
-                    .unwrap());
-                assert!(string1
-                    .equals(&token, String::new(env, &token, "test").unwrap())
-                    .unwrap());
+            assert!(string1
+                .equals(&token, &String::new(&token, "test").unwrap())
+                .unwrap());
+            assert!(string1
+                .equals(&token, Some(&String::new(&token, "test").unwrap()))
+                .unwrap());
+            assert!(string1
+                .equals(&token, Some(String::new(&token, "test").unwrap()))
+                .unwrap());
+            assert!(string1
+                .equals(&token, String::new(&token, "test").unwrap())
+                .unwrap());
 
-                assert_eq!(
-                    object.to_string(&token).unwrap().unwrap().as_string(&token),
-                    format!("java.lang.Object@{:x}", object.hash_code(&token).unwrap())
-                );
+            assert_eq!(
+                object.to_string(&token).unwrap().unwrap().as_string(&token),
+                format!("java.lang.Object@{:x}", object.hash_code(&token).unwrap())
+            );
 
-                assert!(format!("{:?}", object).contains("java.lang.Object@"));
+            assert!(format!("{:?}", object).contains("java.lang.Object@"));
 
-                ((), token)
-            },
-        )
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/rust-jni/tests/string.rs
+++ b/rust-jni/tests/string.rs
@@ -8,42 +8,39 @@ mod string {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let string = String::empty(env, &token).unwrap();
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let string = String::empty(&token).unwrap();
 
-                assert!(string
-                    .class(&token)
-                    .is_same_as(&token, &String::class(env, &token).unwrap(),));
+            assert!(string
+                .class(&token)
+                .is_same_as(&token, &String::class(&token).unwrap(),));
 
-                assert_eq!(string.len(&token), 0);
-                assert_eq!(string.size(&token), 0);
-                assert_eq!(string.as_string(&token), "");
+            assert_eq!(string.len(&token), 0);
+            assert_eq!(string.size(&token), 0);
+            assert_eq!(string.as_string(&token), "");
 
-                assert_eq!(
-                    java::lang::String::new(&env, &token, "")
-                        .unwrap()
-                        .as_string(&token),
-                    ""
-                );
+            assert_eq!(
+                java::lang::String::new(&token, "")
+                    .unwrap()
+                    .as_string(&token),
+                ""
+            );
 
-                let string = String::new(&env, &token, "строка").unwrap();
-                assert_eq!(string.as_string(&token), "строка");
-                assert_eq!(string.len(&token), 6);
-                assert_eq!(string.size(&token), 12);
+            let string = String::new(&token, "строка").unwrap();
+            assert_eq!(string.as_string(&token), "строка");
+            assert_eq!(string.len(&token), 6);
+            assert_eq!(string.size(&token), 12);
 
-                assert_eq!(
-                    String::value_of_int(&env, &token, 17)
-                        .unwrap()
-                        .unwrap()
-                        .as_string(&token),
-                    "17"
-                );
+            assert_eq!(
+                String::value_of_int(&token, 17)
+                    .unwrap()
+                    .unwrap()
+                    .as_string(&token),
+                "17"
+            );
 
-                ((), token)
-            },
-        )
+            ((), token)
+        })
         .unwrap();
     }
 }

--- a/rust-jni/tests/throwable.rs
+++ b/rust-jni/tests/throwable.rs
@@ -8,68 +8,61 @@ mod throwable {
     fn test() {
         let init_arguments = InitArguments::get_default(JniVersion::V8).unwrap();
         let vm = JavaVM::create(&init_arguments).unwrap();
-        vm.with_attached(
-            &AttachArguments::new(init_arguments.version()),
-            |env, token| {
-                let _throwable = Throwable::new(env, &token).unwrap();
+        vm.with_attached(&AttachArguments::new(init_arguments.version()), |token| {
+            let _throwable = Throwable::new(&token).unwrap();
 
-                let throwable = Throwable::new_with_message(
-                    env,
-                    &token,
-                    &String::new(env, &token, "cause").unwrap(),
-                )
-                .unwrap();
+            let throwable =
+                Throwable::new_with_message(&token, &String::new(&token, "cause").unwrap())
+                    .unwrap();
 
-                let _ = Throwable::new_with_cause(env, &token, &throwable).unwrap();
+            let _ = Throwable::new_with_cause(&token, &throwable).unwrap();
 
-                let throwable = Throwable::new_with_message_and_cause(
-                    env,
-                    &token,
-                    &String::new(env, &token, "message").unwrap(),
-                    &throwable,
-                )
-                .unwrap();
+            let throwable = Throwable::new_with_message_and_cause(
+                &token,
+                &String::new(&token, "message").unwrap(),
+                &throwable,
+            )
+            .unwrap();
 
-                assert!(throwable
-                    .class(&token)
-                    .is_same_as(&token, &Throwable::class(env, &token).unwrap()));
+            assert!(throwable
+                .class(&token)
+                .is_same_as(&token, &Throwable::class(&token).unwrap()));
 
-                assert_eq!(
-                    throwable
-                        .get_message(&token)
-                        .unwrap()
-                        .unwrap()
-                        .as_string(&token),
-                    "message"
-                );
+            assert_eq!(
+                throwable
+                    .get_message(&token)
+                    .unwrap()
+                    .unwrap()
+                    .as_string(&token),
+                "message"
+            );
 
-                assert_eq!(
-                    throwable
-                        .get_cause(&token)
-                        .unwrap()
-                        .unwrap()
-                        .get_message(&token)
-                        .unwrap()
-                        .unwrap()
-                        .as_string(&token),
-                    "cause"
-                );
+            assert_eq!(
+                throwable
+                    .get_cause(&token)
+                    .unwrap()
+                    .unwrap()
+                    .get_message(&token)
+                    .unwrap()
+                    .unwrap()
+                    .as_string(&token),
+                "cause"
+            );
 
-                let token = throwable.throw(token);
-                let (throwable, token) = token.unwrap();
+            let token = throwable.throw(token);
+            let (throwable, token) = token.unwrap();
 
-                assert_eq!(
-                    throwable
-                        .get_message(&token)
-                        .unwrap()
-                        .unwrap()
-                        .as_string(&token),
-                    "message"
-                );
+            assert_eq!(
+                throwable
+                    .get_message(&token)
+                    .unwrap()
+                    .unwrap()
+                    .as_string(&token),
+                "message"
+            );
 
-                ((), token)
-            },
-        )
+            ((), token)
+        })
         .unwrap();
     }
 }


### PR DESCRIPTION
By making it obtainable from a `NoException` token.