### PR TITLE
Replace the custom-built `need_drop` flag with `ManualDrop`.

### DIFF
--- a/rust-jni/src/native_method.rs
+++ b/rust-jni/src/native_method.rs
@@ -625,7 +625,7 @@ where
         // Safe because we pass a valid `raw_env` pointer.
         // Will not panic because JNI guarantees that pointers are not null.
         #[allow(unused_unsafe)]
-        let env = ManuallyDrop::new(unsafe { JniEnv::native(&vm, NonNull::new(raw_env).unwrap()) });
+        let env = ManuallyDrop::new(unsafe { JniEnv::new(&vm, NonNull::new(raw_env).unwrap()) });
         let token = env.token();
         callback(token, arguments)
     });

--- a/rust-jni/src/vm.rs
+++ b/rust-jni/src/vm.rs
@@ -204,14 +204,6 @@ impl JavaVMRef {
         }
     }
 
-    pub unsafe fn native_env<'a>(&'a self, raw_env: *mut jni_sys::JNIEnv) -> JniEnv<'a> {
-        // Safe because we pass a valid `raw_env` pointer.
-        // Will not panic because JNI guarantees that pointers are not null.
-        #[allow(unused_unsafe)]
-        let env = unsafe { JniEnv::native(self, NonNull::new(raw_env).unwrap()) };
-        env
-    }
-
     /// Unsafe because:
     /// 1. A user might pass an incorrect pointer.
     /// 2. The current thread might not be attached.


### PR DESCRIPTION
The flag is only used for testing and is making code less readable otherwise.